### PR TITLE
Update MAC address for new demo Senso

### DIFF
--- a/etc/dnsmasq.conf
+++ b/etc/dnsmasq.conf
@@ -10,4 +10,4 @@ dhcp-range=en2,192.168.1.2,192.168.1.100,12h
 ## Static hosts
 
 # Senso Prototype
-dhcp-host=00:50:c2:3d:90:00,192.168.1.10
+dhcp-host=00:50:c2:3d:97:31,192.168.1.10


### PR DESCRIPTION
The old demo Senso has found a new home with a customer.

It would also be possible to assign the same IP to several MAC addresses in this file (and assuming only one is connected at a time).