### PR TITLE
Code signing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ To start with Electron (as in production) run `npm run electron`.
 
 This will start the driver as an Electron application. Note that no window will be created. The application lives in the menubar.
 
-## Building Releases
+## Building the App
 
 To build Electron executables and installers: `npm run build`
 
@@ -122,6 +122,8 @@ Following these instructions, the Senso should have IP `169.254.1.10`.
 
 The Windows version of the driver is packaged into an installer using [Squirrel](https://github.com/Squirrel/Squirrel.Windows). Drivers installed in this way will auto-update by checking `dist.dividat.ch` for new versions periodically.
 
+When building for releasing, all Windows executables have to be signed. The release script will not publish unsigned builds.
+
 ### Checklist
 
 - [ ] Check that changelog is up to date
@@ -134,7 +136,7 @@ The Windows version of the driver is packaged into an installer using [Squirrel]
 
 - `npm run release`
 
-Credentials need to be available for the AWS SDK to pick up.
+Credentials need to be available for the AWS SDK to pick up. `CODE_SIGNING_CERT` and optionally `CODE_SIGNING_PW` need to be set for code signing to happen.
 
 The command will trigger a fresh build and start a release script. The release script expects to release from a clean working tree. It will ask for a version number to use for the release and cross-check it with that in `package.json` and the tag of `HEAD`. If all is well, it will upload the release assets to S3.
 

--- a/bin/build
+++ b/bin/build
@@ -9,11 +9,12 @@ packager(
         icon: 'src/icons/dividat-icon',
         dir: '.',
         out: 'build',
+        appCopyright: `(C) ${new Date().getFullYear()} ${package.author}`,
         win32metadata: {
             CompanyName: package.author,
             ProductName: package.productName,
             InternalName: package.productName,
-            FileDescription: package.description,
+            FileDescription: package.productName,
             OriginalFilename: `${package.productName}.exe`
         }
     },

--- a/bin/package
+++ b/bin/package
@@ -52,7 +52,7 @@ async function createWindowsInstaller(arch) {
 async function signBinaries(dir) {
     return Promise.all(
         util.findBinaries(dir).map(binaryPath => {
-            if (process.env.CODE_SIGNING_CERT == null || process.env.CODE_SIGNING_PW == null) {
+            if (process.env.CODE_SIGNING_CERT == null) {
                 console.warn(`No certificate given, not signing ${binaryPath}`);
                 return Promise.resolve();
             }

--- a/bin/package
+++ b/bin/package
@@ -1,23 +1,29 @@
-#! /usr/bin/env node
+#! /usr/bin/env node --harmony-async-await
+
 const electronInstaller = require('electron-winstaller');
 const rcedit = require('rcedit');
+const signcode = require('signcode');
 const execSync = require('child_process').execSync;
 const fs = require('fs');
 const glob = require('glob');
+const mkdirp = require('mkdirp');
 const path = require('path');
 const JSZip = require('jszip');
 const package = require('../package');
+const util = require('./util');
 
 const distDir = 'build/dist';
 
-function createWindowsInstaller(arch) {
+async function createWindowsInstaller(arch) {
     const outputPath = `${distDir}/win32/${arch}`;
+    const appPath = `build/${package.productName}-win32-${arch}`;
     const setupExeName = `Install ${package.productName} v${package.version}.exe`;
 
-    console.log('Building installer for ' + platformName(arch));
+    await signBinaries(appPath);
 
-    electronInstaller.createWindowsInstaller({
-        appDirectory: `build/${package.productName}-win32-${arch}`,
+    console.log('Building installer for ' + platformName(arch));
+    return electronInstaller.createWindowsInstaller({
+        appDirectory: appPath,
         outputDirectory: outputPath,
         name: 'dividat_driver',
         copyright: `(C) ${new Date().getFullYear()} ${package.author}`,
@@ -26,20 +32,44 @@ function createWindowsInstaller(arch) {
         setupExe: setupExeName,
         noMsi: true,
         remoteReleases: `https://dist.dividat.ch/releases/driver/stable/win32/${arch}`,
+    }).then(() => {
+        // Set icon on installer
+        // Workaround for issue with electron-winstaller
+        // https://github.com/electron/windows-installer/issues/119#issuecomment-279945093
+        return util.promisify(
+            rcedit,
+            `${outputPath}/${setupExeName}`,
+            { icon: 'src/icons/dividat-installer-icon.ico' }
+        );
     }).then(
-        () => {
-            // Workaround for issue with electron-winstaller
-            // https://github.com/electron/windows-installer/issues/119#issuecomment-279945093
-            rcedit(
-                `${outputPath}/${setupExeName}`,
-                { icon: 'src/icons/dividat-installer-icon.ico' },
-                () => {}
+        () => signBinaries(outputPath)
+    ).catch((e) => {
+        console.error(`Error building ${platformName(arch)} installer: ${e.message}`);
+        process.exit(1);
+    });
+}
+
+async function signBinaries(dir) {
+    return Promise.all(
+        util.findBinaries(dir).map(binaryPath => {
+            if (process.env.CODE_SIGNING_CERT == null || process.env.CODE_SIGNING_PW == null) {
+                console.warn(`No certificate given, not signing ${binaryPath}`);
+                return Promise.resolve();
+            }
+
+            console.log(`Signing ${binaryPath}`);
+            return util.promisify(
+                signcode.sign, {
+                    cert: process.env.CODE_SIGNING_CERT,
+                    password: process.env.CODE_SIGNING_PW,
+                    path: binaryPath,
+                    hash: ['sha1', 'sha256'],
+                    name: package.productName,
+                    site: 'https://www.dividat.com/',
+                    overwrite: true
+                }
             );
-        },
-        (e) => {
-            console.error(`Error building ${platformName(arch)} installer: ${e.message}`);
-            process.exit(1);
-        }
+        })
     );
 }
 
@@ -50,7 +80,7 @@ function createMacArchive() {
 
     console.log('Creating archive for darwin');
 
-    execSync(`mkdir -p "${path.dirname(archiveName)}"`);
+    mkdirp.sync(path.dirname(archiveName));
 
     // Create the ZIP archive with Node for portability
     const archive = new JSZip().folder(appName);
@@ -76,5 +106,4 @@ function platformName(arch) {
 
 // We only maintain the installer and update channel for 32 architecture,
 // having no substantial gains from using 64 bit.
-createWindowsInstaller('ia32');
-createMacArchive();
+createWindowsInstaller('ia32').then(createMacArchive);

--- a/bin/package
+++ b/bin/package
@@ -20,6 +20,7 @@ function createWindowsInstaller(arch) {
         appDirectory: `build/${package.productName}-win32-${arch}`,
         outputDirectory: outputPath,
         name: 'dividat_driver',
+        copyright: `(C) ${new Date().getFullYear()} ${package.author}`,
         exe: `${package.productName}.exe`,
         iconUrl: `https://dist.dividat.ch/win32/dividat-icon.ico`,
         setupExe: setupExeName,

--- a/bin/release
+++ b/bin/release
@@ -4,6 +4,7 @@ const constants = require('../src/constants');
 const assert = require('assert');
 const prompt = require('prompt');
 const semver = require('semver');
+const signcode = require('signcode');
 const fs = require('fs');
 const glob = require('glob');
 const path = require('path');
@@ -11,6 +12,7 @@ const spawnSync = require('child_process').spawnSync;
 const execSync = require('child_process').execSync;
 const mime = require('mime-types');
 const aws = new require('aws-sdk');
+const util = require('./util');
 
 // Setup libraries
 
@@ -19,13 +21,12 @@ prompt.message = '';
 
 // Start release
 
-release(
-    {
-        distDir: 'build/dist'
-    }
-).catch(
-    (err) => { console.error(err); process.exit(1); }
-);
+release({
+    distDir: 'build/dist'
+}).catch((err) => {
+    console.error(err);
+    process.exit(1);
+});
 
 async function release(options) {
     prompt.start();
@@ -35,6 +36,15 @@ async function release(options) {
         0,
         "There are uncommited changes."
     );
+
+    try {
+        await Promise.all(util.findBinaries(options.distDir).map(binaryPath =>
+            util.promisify(signcode.verify, { path: binaryPath })
+        ));
+    } catch (err) {
+        console.error('Refusing to release unsigned binaries:', err.message);
+        abort();
+    }
 
     const branch = exec('git rev-parse --abbrev-ref HEAD');
     const channel = channelFromBranch(branch);
@@ -68,7 +78,7 @@ async function release(options) {
 
     console.log('\nUploading assets ...');
 
-    const s3 = new aws.S3({region: 'eu-central-1'});
+    const s3 = new aws.S3({ region: 'eu-central-1' });
     await Promise.all(
         assets.map((assetPath) => {
             const assetName = path.basename(assetPath);

--- a/bin/util.js
+++ b/bin/util.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const glob = require('glob');
+
+exports.promisify = function promisify(func, ...args) {
+    return new Promise((resolve, reject) => {
+        func(
+            ...args,
+            (err, result) => err == null ? resolve(result) : reject(err)
+        );
+    });
+};
+
+exports.findBinaries = function findBinaries(dir) {
+    // See https://github.com/Squirrel/Squirrel.Windows/blob/8877944/src/Squirrel/Utility.cs#L501-L506
+    return glob.sync(`${dir}/**/*.@(exe|dll|node)`);
+};

--- a/package.json
+++ b/package.json
@@ -41,10 +41,12 @@
     "jszip": "^3.1.3",
     "mime-types": "^2.1.14",
     "minimist": "^1.2.0",
+    "mkdirp": "^0.5.1",
     "nodemon": "^1.11.0",
     "prompt": "^1.0.0",
     "rcedit": "^0.7.0",
     "rimraf": "^2.5.4",
-    "semver": "^5.3.0"
+    "semver": "^5.3.0",
+    "signcode": "knuton/signcode#weak-verify"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -240,6 +240,10 @@ camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
+camelcase@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -282,6 +286,14 @@ chromium-pickle-js@^0.1.0:
 chromium-pickle-js@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz#04a106672c18b085ab774d983dfa3ea138f22205"
+
+cliui@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wrap-ansi "^2.0.0"
 
 co@^4.6.0:
   version "4.6.0"
@@ -433,7 +445,7 @@ debug@2.6.3, debug@^2.1.3, debug@^2.6.1:
   dependencies:
     ms "0.7.2"
 
-decamelize@^1.1.2:
+decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -870,6 +882,10 @@ gauge@~2.7.1:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+get-caller-file@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
 get-package-info@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/get-package-info/-/get-package-info-1.0.0.tgz#6432796563e28113cd9474dbbd00052985a4999c"
@@ -1049,6 +1065,10 @@ inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1:
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+invert-kv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
 ipaddr.js@1.2.0:
   version "1.2.0"
@@ -1245,6 +1265,12 @@ latest-version@^1.0.0:
   dependencies:
     package-json "^1.0.0"
 
+lcid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
+  dependencies:
+    invert-kv "^1.0.0"
+
 lie@~3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
@@ -1319,6 +1345,10 @@ lodash.assign@^3.0.0:
     lodash._baseassign "^3.0.0"
     lodash._createassigner "^3.0.0"
     lodash.keys "^3.0.0"
+
+lodash.assign@^4.0.3, lodash.assign@^4.0.6:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
 lodash.defaults@^3.1.2:
   version "3.1.2"
@@ -1644,6 +1674,12 @@ options@>=0.0.5:
 os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+
+os-locale@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+  dependencies:
+    lcid "^1.0.0"
 
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.1:
   version "1.0.2"
@@ -2035,6 +2071,14 @@ request@^2.45.0, request@^2.79.0, request@^2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+
+require-main-filename@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+
 resolve@^1.1.6:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
@@ -2110,7 +2154,7 @@ serve-static@1.12.1:
     parseurl "~1.3.1"
     send "0.15.1"
 
-set-blocking@~2.0.0:
+set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
@@ -2125,6 +2169,13 @@ setprototypeof@1.0.3:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+signcode@knuton/signcode#weak-verify:
+  version "0.5.0"
+  resolved "https://codeload.github.com/knuton/signcode/tar.gz/270714d33809fd59def08577424c80febf7877f4"
+  dependencies:
+    prompt "^1.0.0"
+    yargs "^4.6.0"
 
 single-line-log@^1.1.2:
   version "1.1.2"
@@ -2471,11 +2522,19 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
+which-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
+
 wide-align@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.0.tgz#40edde802a71fea1f070da3e62dcda2e7add96ad"
   dependencies:
     string-width "^1.0.1"
+
+window-size@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
 
 winston@2.1.x:
   version "2.1.1"
@@ -2488,6 +2547,13 @@ winston@2.1.x:
     isstream "0.1.x"
     pkginfo "0.3.x"
     stack-trace "0.0.x"
+
+wrap-ansi@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
 
 wrappy@1:
   version "1.0.2"
@@ -2544,6 +2610,36 @@ xtend@~2.1.1:
 xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+y18n@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+
+yargs-parser@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-2.4.1.tgz#85568de3cf150ff49fa51825f03a8c880ddcc5c4"
+  dependencies:
+    camelcase "^3.0.0"
+    lodash.assign "^4.0.6"
+
+yargs@^4.6.0:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.8.1.tgz#c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0"
+  dependencies:
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    lodash.assign "^4.0.3"
+    os-locale "^1.4.0"
+    read-pkg-up "^1.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^1.0.1"
+    which-module "^1.0.0"
+    window-size "^0.2.0"
+    y18n "^3.2.1"
+    yargs-parser "^2.4.1"
 
 yauzl@2.4.1:
   version "2.4.1"


### PR DESCRIPTION
This adds code signing steps to the package and release scripts. Code signing is done manually using a (hopefully short-lived) fork of [signcode](https://github.com/kevinsawicki/signcode) for two reasons:

1. `rcedit` bundled with electron-winstaller is broken and we already set the icon after the installer has been created, hence have to sign the installer ourselves too
2. Squirrel makes a hard-coded call to Microsoft's `signtool.exe`, which is bundled but does not run on Wine, so there is no out-of-the-box support for signing on non-Windows systems

Implementation is feature complete yet only tested with self-signed certificate.

#### Remaining

- [x] Test with real certificate