### PR TITLE
"nearly always" Zeroconf

### DIFF
--- a/src-test/control.js
+++ b/src-test/control.js
@@ -2,7 +2,7 @@
 
 var net = require('net')
 
-var HOST = '127.0.0.1'
+var HOST = '0.0.0.0'
 var PORT = 55567
 
 // Create a server instance, and chain the listen function to it

--- a/src-test/discover.js
+++ b/src-test/discover.js
@@ -1,0 +1,3 @@
+// Tool to discover Sensos
+
+require('../src/Senso/discovery')()

--- a/src-test/replay.js
+++ b/src-test/replay.js
@@ -2,9 +2,13 @@ const fs = require('fs')
 const split = require('binary-split')
 const net = require('net')
 
+const discovery = require('../src/Senso/discovery')()
+
+discovery._bonjour.publish({name: 'Senso data replayer', type: 'sensoControl', port: '55567'})
+
 const EventEmitter = require('events')
 
-var HOST = '127.0.0.1'
+var HOST = '0.0.0.0'
 var PORT = 55568
 
 module.exports = function (recFile, timeout) {

--- a/src/Senso/discovery.js
+++ b/src/Senso/discovery.js
@@ -1,0 +1,52 @@
+const os = require('os')
+const R = require('ramda')
+const EventEmitter = require('events')
+
+// Discover Senso via mDNS
+
+module.exports = (log) => {
+  log = log || console
+
+  let discovery = new EventEmitter()
+
+  // compute list of interfaces to use for mdns client
+  var interfaces = R.filter(R.identity, R.flatten(R.values(R.map(R.map((ipInfo) => {
+    if (ipInfo.internal === false && ipInfo.family === 'IPv4') {
+      return ipInfo.address
+    } else {
+      return false
+    }
+  }), os.networkInterfaces()))))
+
+  const bonjour = require('bonjour')({
+    // listen on all interfaces
+    interface: interfaces,
+    // use SO_REUSEADDR which allows reuse of address if already bound by an other server. I.e. this allows co-exitsance of certain system level mDNS services with our JS mDNS client.
+    reuseAddr: true
+  })
+
+  // expose bonjour for more advanced usage
+  discovery._bonjour = bonjour
+
+  // Handle case where binding to interface fails. NOTE: this is not standard multicast-dns API!
+  bonjour._server.mdns.on('error', (error) => {
+    switch (error.code) {
+      case 'EADDRINUSE':
+        log.warn('mDNS: Could not bind to address ' + error.address)
+        break
+      default:
+        log.warn('mDNS: Error ' + error.code)
+        break
+    }
+  })
+
+  bonjour.find({type: 'sensoControl'}, (service) => {
+    if (service.addresses[0]) {
+      let address = service.addresses[0]
+      log.info('mDNS: Found Senso at ' + address)
+      discovery.emit('found', address)
+    }
+  })
+
+  return discovery
+}

--- a/src/main.js
+++ b/src/main.js
@@ -22,9 +22,6 @@ let appIcon
 let server
 
 app.on('ready', () => {
-  log.info('Dividat Driver starting.')
-  log.info('Version: ' + pjson.version)
-
     // load server
   server = require('./server')()
 

--- a/src/senso.js
+++ b/src/senso.js
@@ -114,6 +114,7 @@ function factory (sensoAddress, recorder) {
     ws.on('SendControlRaw', (data) => {
       try {
         var socket = controlConnection.getSocket()
+        log.debug('CONTROL: ', data)
         if (socket) {
           socket.write(data)
         } else {

--- a/src/senso.js
+++ b/src/senso.js
@@ -9,7 +9,7 @@ const DEFAULT_SENSO_ADDRESS = 'dividat-senso.local'
 
 const log = require('electron-log')
 
-// TODO: configuration is unnecessary with zeroconf. Remove once all devices have been udated to MDNS enabled firmware
+// TODO: Think about removing configuration on Driver side. If Zeroconf works perfectly no configuration should be needed and otherwise it maybe should be stored on Play side.
 let config
 const constants = require('./constants')
 try {
@@ -77,11 +77,10 @@ function factory (sensoAddress, recorder) {
     // console.error(('Control connection error:, ', err))
   })
 
-  // TODO: remove autoconnect to predefined address (trust that MDNS will work)
   // connect with predifined default
   connect(sensoAddress)
 
-  //
+  // Connect to the first Senso discovered
   bonjour.findOne(bonjourOptions, (service) => {
     if (service.addresses[0]) {
       let address = service.addresses[0]
@@ -115,7 +114,7 @@ function factory (sensoAddress, recorder) {
       })
     }
 
-        // Create a send function so that it can be cleanly removed from the dataEmitter
+    // Create a send function so that it can be cleanly removed from the dataEmitter
     function sendData (data) {
       ws.emit('DataRaw', data)
     }
@@ -131,7 +130,7 @@ function factory (sensoAddress, recorder) {
     controlConnection.on('connect', sendSensoConnection)
     controlConnection.on('close', sendSensoConnection)
 
-    // Setup forwarding of mdns discovery up
+    // Forward the discovery of (additional) Sensos to Play
     bonjour.find(bonjourOptions, (service) => {
       if (service.addresses[0]) {
         ws.emit('BridgeMessage', {
@@ -178,7 +177,7 @@ function factory (sensoAddress, recorder) {
       }
     })
 
-        // handle disconnect
+    // handle disconnect
     ws.on('disconnect', () => {
       log.info('WS: Disconnected.')
 

--- a/src/server.js
+++ b/src/server.js
@@ -21,10 +21,12 @@ if (process.resourcesPath) {
 }
 
 function factory (sensoAddress, recorder) {
+  log.info('Dividat Driver (' + pjson.version + ') starting up...')
+
     // Load and connect Senso
   var senso = require('./senso')(sensoAddress, recorder)
 
-    // Start the server
+  // Start the server
 
   var https = require('https')
   var server = https.createServer({
@@ -33,6 +35,18 @@ function factory (sensoAddress, recorder) {
   }, app)
   server.listen(8380, function () {
     log.info('SERVER: Listening on ' + server.address().port)
+  })
+
+  server.on('error', (error) => {
+    switch (error.code) {
+      case 'EADDRINUSE':
+        log.error('SERVER: Address already in use. Could not start listening.')
+        break
+      default:
+        log.error('SERVER: Error ' + error.code)
+        log.error(error)
+        break
+    }
   })
 
     // socket.io


### PR DESCRIPTION
- Add error handling when mDNS can not bind or server can not listen
- Change default Senso address to dividat-senso.local

This makes setup "almost" or "nearly always" zeroconfig.

I chose not to add the bindings to system mDNS service (avahi, bonjour on windows/mac) and only use the javascript mDNS service. If a mDNS service is installed on the system, the JS mDNS client may fail. This is now handled and driver will not crash. In that case the default address of Senso has been set to "dividat-senso.local" and the system mDNS service will be able to resolve, driver will be able to connect.

If there is no system mDNS service, JS mDNS should work and Senso can be discovered and connected to.

For old installations that do not have mDNS on firmware yet, configurations are still read and basically nothing changes for them.