### PR TITLE
Application level liveliness check

### DIFF
--- a/src/persistentConnection.js
+++ b/src/persistentConnection.js
@@ -31,7 +31,6 @@ module.exports = function Connection (host, port, name, log) {
 
   function onError (err) {
     log.warn(formatLog('Error: ' + err.message))
-    connection.emit('error', err)
   }
 
   function onData (data) {
@@ -44,9 +43,8 @@ module.exports = function Connection (host, port, name, log) {
         log.verbose(formatLog('Timeout while connecting.'))
         connection.connect()
       } else {
-                // log.verbose(formatLog("Sending keepalive."));
-                // var heartBeat = new Buffer(0);
-                // connection.socket.write(heartBeat);
+        // emit a 'timeout' event. This means application logic should do a application level liveliness check
+        connection.emit('timeout')
       }
     }
   }


### PR DESCRIPTION
Implement an application level keep alive and monitoring of Senso status.

Following thoughts:
- TCP is designed to survive link failures (e.g. cable disconnect and connect, Senso reboot)
- Senso will not properly reestablish existing TCP connection on reboot (I think)
--> Senso disappearance has to be monitored on application level.

This PR does that by sending a command to get Senso status, when TCP connection reports idleness. If Senso does not respond to command within 2s, TCP connection is closed and a new connection is attempted.

Additionally Senso status (which is returned after every command) is monitored. Error states are logged in the driver.

Things to think about/discuss:
- Could this possibly be done on Web-side?
- Due to a bug in firmware this only works with fix https://github.com/dividat/senso-firmware/pull/34. Is there a smooth update path?

Attached is a log of what the driver does, while doing following:
 - Senso is connected
 - No commands from Play (send some keepalives)
 - Play sends some commands
 - Unplug Senso
 - Reconnect Senso

[log.txt](https://github.com/dividat/driver/files/1001775/log.txt)
