### PR TITLE
Report TCP timeout to Play

### DIFF
--- a/src/persistentConnection.js
+++ b/src/persistentConnection.js
@@ -44,9 +44,7 @@ module.exports = function Connection (host, port, name, log) {
         log.verbose(formatLog('Timeout while connecting.'))
         connection.connect()
       } else {
-                // log.verbose(formatLog("Sending keepalive."));
-                // var heartBeat = new Buffer(0);
-                // connection.socket.write(heartBeat);
+        connection.emit('timeout')
       }
     }
   }


### PR DESCRIPTION
This is the lighter alternative to #30. Simply report TCP connection timeout to Play and let it worry about what to do.