### PR TITLE
Add release channel functionality to build scripts

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -140,6 +140,16 @@ Credentials need to be available for the AWS SDK to pick up. `CODE_SIGNING_CERT`
 
 The command will trigger a fresh build and start a release script. The release script expects to release from a clean working tree. It will ask for a version number to use for the release and cross-check it with that in `package.json` and the tag of `HEAD`. If all is well, it will upload the release assets to S3.
 
+#### Release Channels
+
+Release channels allow several lines of the software to coexist, for example in order to allow early internal testing of development versions. A driver built for one channel will only ever update itself to new versions on the same channel.
+
+A release channel can be set via environment variable:
+
+- `RELEASE_CHANNEL=stable npm run release`
+
+When no release channel is set, the channel will default to `internal` on `master` and `dev` on all other branches.
+
 ## Contact
 
 Adarsh Amirtham <adarsh@dividat.com>, Dividat GmbH

--- a/bin/build.js
+++ b/bin/build.js
@@ -1,5 +1,8 @@
 #! /usr/bin/env node
+const fs = require('fs')
+const path = require('path')
 const pkg = require('../package.json')
+const util = require('./util')
 const packager = require('electron-packager')
 
 packager(
@@ -16,7 +19,8 @@ packager(
       InternalName: pkg.productName,
       FileDescription: pkg.productName,
       OriginalFilename: `${pkg.productName}.exe`
-    }
+    },
+    afterCopy: [setChannel]
   },
     (err, appPaths) => {
       if (err) {
@@ -25,3 +29,12 @@ packager(
       }
     }
 )
+
+function setChannel (tmpDirPath, _, _, _, done) {
+  const constantsPath = path.join(tmpDirPath, 'src', 'constants.json')
+  const constants = require(constantsPath)
+
+  constants.RELEASE_CHANNEL = util.getChannel()
+  fs.writeFileSync(constantsPath, JSON.stringify(constants))
+  done()
+}

--- a/bin/package.js
+++ b/bin/package.js
@@ -30,7 +30,7 @@ async function createWindowsInstaller (arch) {
     iconUrl: `https://dist.dividat.ch/win32/dividat-icon.ico`,
     setupExe: setupExeName,
     noMsi: true,
-    remoteReleases: `https://dist.dividat.ch/releases/driver/stable/win32/${arch}`
+    remoteReleases: `https://dist.dividat.ch/releases/driver/${util.getChannel()}/win32/${arch}`
   }).then(() => {
         // Set icon on installer
         // Workaround for issue with electron-winstaller

--- a/bin/release.js
+++ b/bin/release.js
@@ -55,15 +55,18 @@ async function release (options) {
   const tag = 'v' + semver.clean(version)
 
   assert.equal(
-        version,
-        require('../package').version,
-        'Version must match with package.json.'
+    version,
+    require('../package').version,
+    'Version must match with package.json.'
+  )
+
+  if (channel !== 'dev') {
+    assert.equal(
+      tag,
+      exec('git describe --exact-match HEAD'),
+      'Version must match with Git tag of HEAD.'
     )
-  assert.equal(
-        tag,
-        exec('git describe --exact-match HEAD'),
-        'Version must match with Git tag of HEAD.'
-    )
+  }
 
   const commit = exec('git rev-parse HEAD')
   console.log(`\nThe latest commit on ${branch} is: \n`)

--- a/bin/release.js
+++ b/bin/release.js
@@ -46,7 +46,7 @@ async function release (options) {
   }
 
   const branch = exec('git rev-parse --abbrev-ref HEAD')
-  const channel = channelFromBranch(branch)
+  const channel = util.getChannel()
 
   const version = (await query('tag', {
     description: 'Please enter semver number for this release',
@@ -143,17 +143,6 @@ function exec (cmd) {
 
 function indent (block) {
   return block.replace(/^(?!\s*$)/mg, '    ')
-}
-
-function channelFromBranch (branchName) {
-  switch (branchName) {
-    case 'master':
-      return 'stable'
-        // TODO Introduce a dev channel
-    case 'develop':
-    default:
-      return 'stable'
-  }
 }
 
 function cacheControl (path) {

--- a/bin/util.js
+++ b/bin/util.js
@@ -1,16 +1,34 @@
-const fs = require('fs');
-const glob = require('glob');
+const execSync = require('child_process').execSync
+const fs = require('fs')
+const glob = require('glob')
 
-exports.promisify = function promisify(func, ...args) {
-    return new Promise((resolve, reject) => {
-        func(
+exports.promisify = function promisify (func, ...args) {
+  return new Promise((resolve, reject) => {
+    func(
             ...args,
             (err, result) => err == null ? resolve(result) : reject(err)
-        );
-    });
-};
+        )
+  })
+}
 
-exports.findBinaries = function findBinaries(dir) {
+exports.findBinaries = function findBinaries (dir) {
     // See https://github.com/Squirrel/Squirrel.Windows/blob/8877944/src/Squirrel/Utility.cs#L501-L506
-    return glob.sync(`${dir}/**/*.@(exe|dll|node)`);
-};
+  return glob.sync(`${dir}/**/*.@(exe|dll|node)`)
+}
+
+// Determine the channel to release to
+exports.getChannel = function getChannel () {
+  // Prefer explicit parameters
+  if (process.env.RELEASE_CHANNEL) {
+    return process.env.RELEASE_CHANNEL
+  }
+
+  // Or infer from current branch
+  switch (execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim()) {
+    case 'master':
+      return 'internal'
+    case 'develop':
+    default:
+      return 'dev'
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "nodemon src/server.js",
     "electron": "electron .",
     "build": "rimraf build && mkdir -p build && node bin/build.js && node bin/package.js",
-    "release": "npm run build && node bin/release.js",
+    "release": "node bin/release.js",
     "replay": "nodemon --watch src-test/ src-test/",
     "test": "node test/smoke.js"
   },

--- a/src/constants.json
+++ b/src/constants.json
@@ -1,4 +1,5 @@
 {
     "SENSO_ADDRESS_KEY": "senso.address",
-    "PLAY_URL": "https://play.dividat.com/"
+    "PLAY_URL": "https://play.dividat.com/",
+    "RELEASE_CHANNEL": "dev"
 }

--- a/src/installation/handle-squirrel-events.js
+++ b/src/installation/handle-squirrel-events.js
@@ -108,7 +108,7 @@ function scheduleUpdateCheck () {
 }
 
 function checkForUpdates () {
-  electron.autoUpdater.setFeedURL(`https://dist.dividat.ch/releases/driver/stable/win32/ia32`)
+  electron.autoUpdater.setFeedURL(`https://dist.dividat.ch/releases/driver/${constants.RELEASE_CHANNEL}/win32/ia32`)
     // If an update is available, it will be downloaded, but not installed until
     // the application is quit and restarted. We don't bother the user with an
     // "update available" message but trust that the application will be restarted,


### PR DESCRIPTION
The intended release channel needs to be known at all stages of preparing a release:

- building, to bake in the endpoint to check for updates,
- packaging, to check the right endpoint for creating delta updates,
- releasing, to release to the appropriate destination.

Stable channel is never set automatically to avoid accidents.