### PR TITLE
Start mdns-listener on new devices

### DIFF
--- a/src/Senso/discovery.js
+++ b/src/Senso/discovery.js
@@ -1,14 +1,9 @@
 const os = require('os')
 const R = require('ramda')
 const EventEmitter = require('events')
+const bonjour = require('bonjour')
 
-// Discover Senso via mDNS
-
-module.exports = (log) => {
-  log = log || console
-
-  let discovery = new EventEmitter()
-
+function findInterfaces () {
   // compute list of interfaces to use for mdns client
   var interfaces = R.filter(R.identity, R.flatten(R.values(R.map(R.map((ipInfo) => {
     if (ipInfo.internal === false && ipInfo.family === 'IPv4') {
@@ -18,35 +13,70 @@ module.exports = (log) => {
     }
   }), os.networkInterfaces()))))
 
-  const bonjour = require('bonjour')({
-    // listen on all interfaces
-    interface: interfaces,
-    // use SO_REUSEADDR which allows reuse of address if already bound by an other server. I.e. this allows co-exitsance of certain system level mDNS services with our JS mDNS client.
-    reuseAddr: true
-  })
+  return interfaces
+}
 
-  // expose bonjour for more advanced usage
-  discovery._bonjour = bonjour
+// Discover Senso via mDNS
+module.exports = (log) => {
+  log = log || console
 
-  // Handle case where binding to interface fails. NOTE: this is not standard multicast-dns API!
-  bonjour._server.mdns.on('error', (error) => {
-    switch (error.code) {
-      case 'EADDRINUSE':
-        log.warn('mDNS: Could not bind to address ' + error.address)
-        break
-      default:
-        log.warn('mDNS: Error ' + error.code)
-        break
+  let discovery = new EventEmitter()
+
+  // An hash map of interfaces we are listening on to the bonjour object
+  discovery.bonjours = {}
+
+  function listenOnInterfaces () {
+    // Get a list of active interfaces
+    const interfaces = findInterfaces()
+
+    const newInterfaces = R.difference(interfaces, R.keys(discovery.bonjours))
+    const removedInterfaces = R.difference(R.keys(discovery.bonjours), interfaces)
+
+    // Listen on new interfaces
+    for (let i = 0; i < newInterfaces.length; i++) {
+      const iface = newInterfaces[i]
+      log.info('mDNS: Listening on ' + iface)
+
+      discovery.bonjours[iface] = bonjour({
+        interface: iface,
+        // use SO_REUSEADDR which allows reuse of address if already bound by an other server. I.e. this allows co-exitsance of certain system level mDNS services with our JS mDNS client.
+        reuseAddr: true
+      })
+
+      // Handle case where binding to interface fails. NOTE: this is not standard multicast-dns API!
+      discovery.bonjours[iface]._server.mdns.on('error', (error) => {
+        switch (error.code) {
+          case 'EADDRINUSE':
+            log.warn('mDNS: Could not bind to address ' + error.address)
+            break
+          default:
+            log.warn('mDNS: Error ' + error.code)
+            break
+        }
+      })
+
+      discovery.bonjours[iface].find({type: 'sensoControl'}, (service) => {
+        if (service.addresses[0]) {
+          // console.log(service)
+          let address = service.addresses[0]
+          log.info('mDNS: Found Senso at ' + address)
+          discovery.emit('found', address)
+        }
+      })
     }
-  })
 
-  bonjour.find({type: 'sensoControl'}, (service) => {
-    if (service.addresses[0]) {
-      let address = service.addresses[0]
-      log.info('mDNS: Found Senso at ' + address)
-      discovery.emit('found', address)
+    // Remove old interfaces
+    for (let i = 0; i < removedInterfaces.length; i++) {
+      const iface = removedInterfaces[i]
+      delete discovery.bonjours[iface]
+      log.info('mNDS: Removing interface ' + iface)
     }
-  })
+  }
+
+  listenOnInterfaces()
+
+  // Check for new interfaces every 5 seconds
+  setInterval(listenOnInterfaces, 5000)
 
   return discovery
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,6 +254,10 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+browser-stdout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+
 buffer-indexof@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.0.tgz#f54f647c4f4e25228baa656a2e57e43d5f270982"
@@ -370,7 +374,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.9.0:
+commander@2.9.0, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -514,6 +518,12 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
+debug@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
+  dependencies:
+    ms "0.7.2"
+
 debug@2.6.1, debug@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
@@ -569,6 +579,10 @@ depd@1.1.0, depd@~1.1.0:
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
+
+diff@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 dns-equal@^1.0.0:
   version "1.0.0"
@@ -773,7 +787,7 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@^1.0.2:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -1059,17 +1073,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.5, glob@^7.1.1:
+glob@7.1.1, glob@^7.0.5, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -1077,6 +1081,16 @@ glob@^7.0.5, glob@^7.1.1:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -1102,6 +1116,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6,
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
+growl@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -1129,6 +1147,10 @@ has-binary@0.1.7:
 has-cors@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
+
+has-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -1477,6 +1499,10 @@ lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
 
+lodash._basecreate@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
+
 lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
@@ -1508,6 +1534,14 @@ lodash.assign@^3.0.0:
     lodash._baseassign "^3.0.0"
     lodash._createassigner "^3.0.0"
     lodash.keys "^3.0.0"
+
+lodash.create@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
+  dependencies:
+    lodash._baseassign "^3.0.0"
+    lodash._basecreate "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
 
 lodash.defaults@^3.1.2:
   version "3.1.2"
@@ -1655,7 +1689,7 @@ mkdirp@0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -1672,6 +1706,22 @@ mksnapshot@^0.3.0:
     decompress-zip "0.3.0"
     fs-extra "0.26.7"
     request "^2.79.0"
+
+mocha@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.4.2.tgz#d0ef4d332126dbf18d0d640c9b382dd48be97594"
+  dependencies:
+    browser-stdout "1.3.0"
+    commander "2.9.0"
+    debug "2.6.0"
+    diff "3.2.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.1"
+    growl "1.9.2"
+    json3 "3.3.2"
+    lodash.create "3.1.1"
+    mkdirp "0.5.1"
+    supports-color "3.1.2"
 
 ms@0.7.1:
   version "0.7.1"
@@ -2550,6 +2600,12 @@ sumchecker@^2.0.1:
   resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-2.0.2.tgz#0f42c10e5d05da5d42eea3e56c3399a37d6c5b3e"
   dependencies:
     debug "^2.2.0"
+
+supports-color@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
+  dependencies:
+    has-flag "^1.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Observed problem: Driver app is started before all network interfaces are created. When a new interface is added later the mDNS listener is not properly started and Senso can not be discovered on that interface.

This solves it by refreshing the list of interfaces every 5 seconds and start an individual mdns-listener on new devices.