### PR TITLE
Unify platforms into common version

### DIFF
--- a/src/senso.js
+++ b/src/senso.js
@@ -50,7 +50,7 @@ module.exports = (sensoAddress, recorder) => {
     log.verbose('CONTROL: connection error', err)
   })
 
-  // connect with predifined default
+  // connect with predefined default
   connect(sensoAddress)
 
   function connect (address) {

--- a/src/senso.js
+++ b/src/senso.js
@@ -53,6 +53,11 @@ module.exports = (sensoAddress, recorder) => {
   // connect with predefined default
   connect(sensoAddress)
 
+  // On Linux installations, connect to any Senso discovered
+  if (process.platform === 'linux') {
+    discovery.on('found', connect)
+  }
+
   function connect (address) {
     log.info('SENSO: Connecting to ' + address)
     dataConnection.connect(address)


### PR DESCRIPTION
This brings the functionality from `linux-link-local` back into the main line to prevent maintenance of separate branch lines.