### PR TITLE
Add support for PC/SC card readers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ CHECKSUM_SIGNING_CERT ?= ./keys/checksumsign.private.pem
 ### Simple build ##########################################
 .PHONY: $(BIN)
 $(BIN): deps
-	GOROOT=$(GOROOT) GOPATH=$(GOPATH) CC=$(CC) CXX=$(CXX) go build $(GO_LDFLAGS) $(GO_CFLAGS) -o bin/$(BIN) $(SRC)
+	GOROOT=$(GOROOT) GOPATH=$(GOPATH) CC=$(CC) CXX=$(CXX) go build $(GO_LDFLAGS) -o bin/$(BIN) $(SRC)
 
 
 ### Test suite ##########################################

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,15 @@ CC := gcc
 CXX := g++
 
 # Force static linking on Linux
+PCSCLITE_DIR := $(CWD)libpcsclite
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 	STATIC_LINKING_LDFLAGS := -linkmode external -extldflags \"-static\"
 	CC := musl-gcc
 	CXX := musl-gcc
+
+	LIB_PCSCLITE := $(PCSCLITE_DIR)
+	export PKG_CONFIG_PATH=$(PCSCLITE_DIR)/lib/pkgconfig:$$PKG_CONFIG_PATH
 endif
 
 GO_LDFLAGS = -ldflags "$(STATIC_LINKING_LDFLAGS) -X dividat-driver/server.channel=$(CHANNEL) -X dividat-driver/server.version=$(VERSION) -X dividat-driver/update.releaseUrl=$(RELEASE_URL)"
@@ -43,7 +47,7 @@ CHECKSUM_SIGNING_CERT ?= ./keys/checksumsign.private.pem
 ### Simple build ##########################################
 .PHONY: $(BIN)
 $(BIN): deps
-	GOROOT=$(GOROOT) GOPATH=$(GOPATH) CC=$(CC) CXX=$(CXX) go build $(GO_LDFLAGS) -o bin/$(BIN) $(SRC)
+	GOROOT=$(GOROOT) GOPATH=$(GOPATH) CC=$(CC) CXX=$(CXX) go build $(GO_LDFLAGS) $(GO_CFLAGS) -o bin/$(BIN) $(SRC)
 
 
 ### Test suite ##########################################
@@ -152,10 +156,29 @@ deploy: release
 
 
 ### Dependencies and cleanup ##############################
-deps:
+deps: $(LIB_PCSCLITE)
 	cd src/$(BIN) && dep ensure
+
+$(PCSCLITE_DIR):
+	curl -LO https://github.com/LudovicRousseau/PCSC/archive/pcsc-1.8.23.tar.gz
+	mkdir -p tmp/pcsclite && tar xzf pcsc-1.8.23.tar.gz -C tmp/pcsclite --strip-components=1
+	cd tmp/pcsclite; \
+		./bootstrap; \
+		CC=musl-gcc ./configure \
+			--enable-static \
+			--prefix=$(PCSCLITE_DIR) \
+			--with-systemdsystemunitdir=$(PCSCLITE_DIR)/lib/systemd/system \
+			--disable-libudev \
+			--disable-libusb \
+			--disable-libsystemd; \
+		make; \
+		make install
+	rm -rf tmp/pcsclite
+	rm pcsc-1.8.23.tar.gz
+
 
 clean:
 	rm -rf release/
+	rm -rf $(PCSCLITE_DIR)
 	rm -f $(CHECK_VERSION_BIN)
 	go clean

--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,9 @@ stdenv.mkDerivation {
 
         # for deployment to S3
         awscli
+
+        # PCSC on Darwin
+        (if stdenv.isDarwin then pkgs.darwin.apple_sdk.frameworks.PCSC else null)
       ]
       ++
       (if stdenv.isLinux then

--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,10 @@
 with import <nixpkgs> {
-  overlays = [ 
+  overlays = [
     (self: super: {
       dep = import ./nix/dep.nix super;
     })
   ];
 };
-
 
 
 stdenv.mkDerivation {
@@ -20,6 +19,10 @@ stdenv.mkDerivation {
       gcc
       # Required for static linking on Linux
       (if stdenv.isDarwin then null else musl)
+
+      # pcsclite
+      pkgconfig
+      (if stdenv.isLinux then pcsclite else null)
 
       # node for tests
       nodejs-8_x

--- a/default.nix
+++ b/default.nix
@@ -24,17 +24,14 @@ stdenv.mkDerivation {
         # for deployment to S3
         awscli
 
-        # PCSC on Darwin
-        (if stdenv.isDarwin then pkgs.darwin.apple_sdk.frameworks.PCSC else null)
       ]
-      ++
-      (if stdenv.isLinux then
+      # PCSC on Darwin
+      ++ lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.PCSC
+      ++ lib.optionals stdenv.isLinux
           [ # glibc replacement for static linking
             musl
             # Building pcsclite
             pkgconfig autoconf automake libtool flex
           ]
-        else
-          []
-      );
+      ;
 }

--- a/default.nix
+++ b/default.nix
@@ -10,24 +10,28 @@ with import <nixpkgs> {
 stdenv.mkDerivation {
     name = "dividat-driver";
     builder = "${bash}/bin/bash";
-    buildInputs = [
-      go_1_9
-      dep
-      # Git is a de facto dependency of dep
-      git
+    buildInputs =
+      [ go_1_9
+        dep
+        # Git is a de facto dependency of dep
+        git
 
-      gcc
-      # Required for static linking on Linux
-      (if stdenv.isDarwin then null else musl)
+        gcc
 
-      # pcsclite
-      pkgconfig
-      (if stdenv.isLinux then pcsclite else null)
+        # node for tests
+        nodejs-8_x
 
-      # node for tests
-      nodejs-8_x
-
-      # for deployment to S3
-      awscli
-    ];
+        # for deployment to S3
+        awscli
+      ]
+      ++
+      (if stdenv.isLinux then
+          [ # glibc replacement for static linking
+            musl
+            # Building pcsclite
+            pkgconfig autoconf automake libtool flex
+          ]
+        else
+          []
+      );
 }

--- a/src/dividat-driver/Gopkg.lock
+++ b/src/dividat-driver/Gopkg.lock
@@ -24,6 +24,11 @@
   revision = "e59b4a9b1b28de48436e47104472050658bacfcf"
 
 [[projects]]
+  name = "github.com/ebfe/scard"
+  packages = ["."]
+  revision = "136eebbd7d749e6354ed1bb105b88f89c7d80b03"
+
+[[projects]]
   name = "github.com/gorilla/websocket"
   packages = ["."]
   revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"

--- a/src/dividat-driver/Gopkg.toml
+++ b/src/dividat-driver/Gopkg.toml
@@ -40,6 +40,10 @@ ignored = ["server","senso"]
   version = "1.2.0"
 
 [[constraint]]
+  name = "github.com/ebfe/scard"
+  revision = "136eebbd7d749e6354ed1bb105b88f89c7d80b03"
+
+[[constraint]]
   name = "github.com/grandcat/zeroconf"
 
 [[constraint]]

--- a/src/dividat-driver/rfid/main.go
+++ b/src/dividat-driver/rfid/main.go
@@ -163,7 +163,7 @@ func (handle *Handle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Send initial list of readers if it has been set
-	if *handle.knownReaders != nil {
+	if handle.knownReaders != nil {
 		send(Message{ReadersChanged: handle.knownReaders})
 	}
 

--- a/src/dividat-driver/rfid/main.go
+++ b/src/dividat-driver/rfid/main.go
@@ -1,0 +1,193 @@
+package rfid
+
+import (
+	"context"
+	"time"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sync"
+
+	"github.com/gorilla/websocket"
+	"github.com/cskr/pubsub"
+	"github.com/sirupsen/logrus"
+)
+
+const Topic = "rfid-tokens"
+
+// RFID handle
+
+type Handle struct {
+	broker *pubsub.PubSub
+
+	ctx context.Context
+
+	cancelPolling context.CancelFunc
+	subscriberCount int
+
+	log *logrus.Entry
+}
+
+func NewHandle(ctx context.Context, log *logrus.Entry) *Handle {
+	handle := Handle{
+		broker: pubsub.New(2),
+		ctx: ctx,
+		log: log,
+	}
+
+	// Clean up
+	go func() {
+		<-ctx.Done()
+		handle.broker.Shutdown()
+	}()
+
+	return &handle
+}
+
+func (handle *Handle) DeregisterSubscriber() {
+	handle.subscriberCount--
+
+	if handle.subscriberCount == 0 {
+		handle.cancelPolling()
+		handle.cancelPolling = nil
+	}
+}
+
+func (handle *Handle) EnsureSmartCardPolling() {
+	if handle.cancelPolling == nil {
+		ctx, cancel := context.WithCancel(handle.ctx)
+		handle.cancelPolling = cancel
+		// Start a polling routine and push any tokens it produces onto the bus
+		go pollSmartCard(ctx, handle.log, func(token string) {
+			handle.broker.TryPub(Message{ Identified: &token }, Topic)
+		})
+	}
+
+	handle.subscriberCount++
+}
+
+
+// WEBSOCKET PROTOCOL
+
+// Message that can be sent to Play
+type Message struct {
+	Identified *string
+}
+
+func (message *Message) MarshalJSON() ([]byte, error) {
+	if message.Identified != nil {
+		return json.Marshal(&struct {
+			Type   string  `json:"type"`
+			Token *string `json:"token"`
+		}{
+			Type:    "Identified",
+			Token: message.Identified,
+		})
+
+	}
+
+	return nil, errors.New("could not marshal message")
+}
+
+func (handle *Handle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	handle.EnsureSmartCardPolling()
+
+	// Set up logger
+	var log = handle.log.WithFields(logrus.Fields{
+		"clientAddress": r.RemoteAddr,
+		"userAgent":     r.UserAgent(),
+	})
+
+	// Upgrade to WebSocket
+	conn, err := webSocketUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.WithError(err).Error("Could not upgrade connection to WebSocket.")
+		http.Error(w, "WebSocket upgrade error", http.StatusBadRequest)
+		return
+	}
+
+	log.Info("WebSocket connection opened")
+
+	// Create a mutex for writing to WebSocket (connection supports only one concurrent reader and one concurrent writer (https://godoc.org/github.com/gorilla/websocket#hdr-Concurrency))
+	writeMutex := sync.Mutex{}
+
+	// Create a context for this WebSocket connection
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Subscribe to tokens and proxy received messages
+	rx := handle.broker.Sub(Topic)
+	go rx_data_loop(ctx, rx, func(message Message) error {
+		writeMutex.Lock()
+		conn.SetWriteDeadline(time.Now().Add(50 * time.Millisecond))
+		err := conn.WriteJSON(&message)
+		writeMutex.Unlock()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
+				log.WithError(err).Error("WebSocket error")
+			}
+			return err
+		}
+		return nil
+	})
+
+	// Helper function to close the connection
+	close := func() {
+		handle.broker.Unsub(rx)
+
+		// Cancel the context
+		cancel()
+
+		// Close websocket connection
+		conn.Close()
+
+		handle.DeregisterSubscriber()
+
+		log.Info("WebSocket connection closed")
+	}
+
+	// Main loop for the WebSocket connection
+	go func() {
+		defer close()
+		for {
+
+			_, _, err := conn.ReadMessage()
+			if err != nil {
+				if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
+					log.WithError(err).Error("WebSocket error")
+				}
+				return
+			}
+
+		}
+	}()
+
+}
+
+func rx_data_loop(ctx context.Context, rx chan interface{}, send func(Message) error) {
+	var err error
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case i := <-rx:
+			data, ok := i.(Message)
+			if ok {
+				err = send(data)
+			}
+		}
+
+		if err != nil {
+			return
+		}
+	}
+}
+
+// Helper to upgrade http to WebSocket
+var webSocketUpgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}

--- a/src/dividat-driver/rfid/pcsc.go
+++ b/src/dividat-driver/rfid/pcsc.go
@@ -1,0 +1,96 @@
+package rfid
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ebfe/scard"
+	"github.com/sirupsen/logrus"
+)
+
+const UID_APDU = []byte{0xFF, 0xCA, 0x00, 0x00, 0x00}
+
+func pollSmartCard(ctx context.Context, log *logrus.Entry, callback func(string)) {
+	log.Info("Starting RFID scanner.")
+
+	// Establish a PC/SC context
+	context, err := scard.EstablishContext()
+	if err != nil {
+		log.WithError(err).Error("Error EstablishContext:")
+		return
+	}
+	defer context.Release()
+
+	var reader *string
+	var uid *string
+
+	for {
+
+		// Throttle loop
+		time.Sleep(50 * time.Millisecond)
+
+		select {
+		case <-ctx.Done():
+			log.Info("Stopping RFID scanner.")
+			return
+
+		default:
+			// TODO Use GetStatusChange to avoid polling on Linux/Win
+			readers, err := context.ListReaders()
+			if err != nil {
+				log.WithError(err).Error("Error ListReaders:")
+				return
+			}
+
+			if len(readers) == 0 {
+				reader = nil
+				uid = nil
+
+				continue
+			}
+
+			// TODO This just uses the first reader. What is a proper seletion criterion?
+			if reader == nil || *reader != readers[0] {
+				reader = &readers[0]
+				log.Info(fmt.Sprintf("Using reader: %s", *reader))
+			}
+
+			// Wait for card presence
+			readerStates := []scard.ReaderState{
+				{Reader: *reader},
+			}
+			context.GetStatusChange(readerStates, -1)
+			if (readerStates[0].EventState & scard.StatePresent) == 0 {
+				continue
+			}
+
+			// Connect to the card
+			card, err := context.Connect(*reader, scard.ShareShared, scard.ProtocolAny)
+			if err != nil {
+				log.WithError(err).Error("Error Connect:")
+				uid = nil
+				continue
+			}
+
+			// Request UID
+			response, err := card.Transmit(UID_APDU)
+			if err != nil {
+				log.WithError(err).Debug("Error Transmit:")
+				uid = nil
+				continue
+			}
+			scanned_uid := ""
+			for i := 0; i < len(response)-2; i++ {
+				scanned_uid += fmt.Sprintf("%X", response[i])
+			}
+			if len(scanned_uid) > 0 && (uid == nil || *uid != scanned_uid) {
+				uid = &scanned_uid
+				log.Info("Detected RFID token.")
+				callback(*uid)
+			}
+
+			card.Disconnect(scard.LeaveCard)
+		}
+	}
+}

--- a/src/dividat-driver/rfid/pcsc.go
+++ b/src/dividat-driver/rfid/pcsc.go
@@ -9,8 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var READER_POLLING_INTERVAL = 500 * time.Millisecond
-var CARD_POLLING_INTERVAL = 50 * time.Millisecond
+var READER_POLLING_INTERVAL = 1 * time.Second
+var CARD_POLLING_TIMEOUT = 1 * time.Second
 
 // Special MSFT name to bolt plug&play onto PC/SC
 // Supported by winscard and libpcsc
@@ -37,107 +37,112 @@ func pollSmartCard(ctx context.Context, log *logrus.Entry, callback func(string)
 
 	log.WithField("pnp", hasPnP).Info("Starting RFID scanner.")
 
-	var availableReaders []string = make([]string, 0)
-	var lastKnownState map[string]scard.StateFlag = map[string]scard.StateFlag{}
+	go waitForCardActivity(log, scard_ctx, hasPnP, callback)
+
+	<-ctx.Done()
+	// Cancel `GetStatusChange`
+	scard_ctx.Cancel()
+
+	log.Info("Stopping RFID scanner.")
+}
+
+func waitForCardActivity(log *logrus.Entry, scard_ctx *scard.Context, hasPnP bool, callback func(string)) {
+	availableReaders := make([]string, 0)
+	lastKnownState := map[string]scard.StateFlag{}
 
 	for {
-
-		select {
-		case <-ctx.Done():
-			log.Info("Stopping RFID scanner.")
+		// Retrieve available readers
+		newReaders, err := scard_ctx.ListReaders()
+		if err != nil {
+			log.WithError(err).Error("Error listing readers.")
 			return
+		}
+		announceReaderChanges(log, availableReaders, newReaders)
+		availableReaders = newReaders
 
-		default:
-			// Retrieve available readers
-			newReaders, err := scard_ctx.ListReaders()
+		// Wait for readers to appear
+		if len(availableReaders) == 0 {
+			if hasPnP {
+				// `GetStatusChange` acts as a smarter sleep that finishes early
+				code := scard_ctx.GetStatusChange(
+					[]scard.ReaderState{makeReaderState(MAGIC_PNP_NAME)},
+					READER_POLLING_INTERVAL,
+				)
+				if code == scard.ErrCancelled {
+					return
+				}
+			} else {
+				time.Sleep(READER_POLLING_INTERVAL)
+			}
+
+			// Restart loop to list readers
+			continue
+		}
+
+		// Now there are available readers
+		// Wait for card presence
+		readerStates := make([]scard.ReaderState, len(availableReaders))
+		for ix, readerName := range availableReaders {
+			flag, ok := lastKnownState[readerName]
+			if ok {
+				readerStates[ix] = makeReaderState(readerName, flag)
+			} else {
+				readerStates[ix] = makeReaderState(readerName)
+			}
+		}
+		// We need to timeout perodically to check for new readers
+		code := scard_ctx.GetStatusChange(readerStates, CARD_POLLING_TIMEOUT)
+		if code == scard.ErrCancelled {
+			return
+		} else if code != nil {
+			continue
+		}
+
+		// One or more readers changed their status
+		for _, readerState := range readerStates {
+
+			if readerState.CurrentState == readerState.EventState {
+				// This reader has not changed.
+				continue
+			}
+
+			if is(readerState.EventState, scard.StateChanged) {
+				// Event state becomes current state
+				readerState.CurrentState = readerState.EventState
+				// Keep track of last known state for next refresh cycle
+				lastKnownState[readerState.Reader] = readerState.CurrentState
+			} else {
+				continue
+			}
+
+			if !is(readerState.CurrentState, scard.StatePresent) {
+				// This reader has no card.
+				continue
+			}
+
+			// Connect to the card
+			card, err := scard_ctx.Connect(readerState.Reader, scard.ShareShared, scard.ProtocolAny)
 			if err != nil {
-				log.WithError(err).Error("Error listing readers.")
-				return
-			}
-			announceReaderChanges(log, availableReaders, newReaders)
-			availableReaders = newReaders
-
-			// Wait for readers to appear
-			if len(availableReaders) == 0 {
-				if hasPnP {
-					// `GetStatusChange` acts as a smarter sleep that finishes early
-					pnpReaderStates := []scard.ReaderState{
-						makeReaderState(MAGIC_PNP_NAME),
-					}
-					scard_ctx.GetStatusChange(pnpReaderStates, READER_POLLING_INTERVAL)
-				} else {
-					time.Sleep(READER_POLLING_INTERVAL)
-				}
-
-				// Restart loop to list readers
+				log.WithError(err).Error("Error connecting to card.")
 				continue
 			}
 
-			// Now there are available readers
-			// Wait for card presence
-			readerStates := make([]scard.ReaderState, len(availableReaders))
-			for ix, readerName := range availableReaders {
-				flag, ok := lastKnownState[readerName]
-				if ok {
-					readerStates[ix] = makeReaderState(readerName, flag)
-				} else {
-					readerStates[ix] = makeReaderState(readerName)
-				}
-			}
-			// We could block until a card status changes here, but have to
-			// unblock periodically to check if our context has been cancelled
-			code := scard_ctx.GetStatusChange(readerStates, CARD_POLLING_INTERVAL)
-			if code == scard.ErrTimeout {
+			// Request UID
+			response, err := card.Transmit(UID_APDU)
+			if err != nil {
+				log.WithError(err).Debug("Failed while transmitting APDU.")
 				continue
 			}
-
-			// One or more readers changed their status
-			for _, readerState := range readerStates {
-				fmt.Println("LOOPING readers")
-
-				if readerState.CurrentState == readerState.EventState {
-					// This reader has not changed.
-					continue
-				}
-
-				if is(readerState.EventState, scard.StateChanged) {
-					// Event state becomes current state
-					readerState.CurrentState = readerState.EventState
-					// Keep track of last known state for next refresh cycle
-					lastKnownState[readerState.Reader] = readerState.CurrentState
-				} else {
-					continue
-				}
-
-				if !is(readerState.CurrentState, scard.StatePresent) {
-					// This reader has no card.
-					continue
-				}
-
-				// Connect to the card
-				card, err := scard_ctx.Connect(readerState.Reader, scard.ShareShared, scard.ProtocolAny)
-				if err != nil {
-					log.WithError(err).Error("Error connecting to card.")
-					continue
-				}
-
-				// Request UID
-				response, err := card.Transmit(UID_APDU)
-				if err != nil {
-					log.WithError(err).Debug("Failed while transmitting APDU.")
-					continue
-				}
-				uid := ""
-				for i := 0; i < len(response)-2; i++ {
-					uid += fmt.Sprintf("%X", response[i])
-				}
-				if len(uid) > 0 {
-					log.Info("Detected RFID token.")
-					callback(uid)
-				}
-
-				card.Disconnect(scard.UnpowerCard)
+			uid := ""
+			for i := 0; i < len(response)-2; i++ {
+				uid += fmt.Sprintf("%X", response[i])
 			}
+			if len(uid) > 0 {
+				log.Info("Detected RFID token.")
+				callback(uid)
+			}
+
+			card.Disconnect(scard.UnpowerCard)
 		}
 	}
 }

--- a/src/dividat-driver/server/main.go
+++ b/src/dividat-driver/server/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"dividat-driver/logging"
+	"dividat-driver/rfid"
 	"dividat-driver/senso"
 	"dividat-driver/update"
 )
@@ -65,6 +66,10 @@ func Start(interactive bool) context.CancelFunc {
 	// Setup Senso
 	sensoHandle := senso.New(ctx, baseLog.WithField("package", "senso"))
 	http.Handle("/senso", sensoHandle)
+
+	// Setup RFID scanner
+	rfidHandle := rfid.NewHandle(ctx, baseLog.WithField("package", "rfid"))
+	http.Handle("/rfid", rfidHandle)
 
 	// Create a logger for server
 	log := baseLog.WithField("package", "server")

--- a/src/dividat-driver/server/main.go
+++ b/src/dividat-driver/server/main.go
@@ -69,7 +69,9 @@ func Start(interactive bool) context.CancelFunc {
 
 	// Setup RFID scanner
 	rfidHandle := rfid.NewHandle(ctx, baseLog.WithField("package", "rfid"))
+	// net/http performs a redirect from `/rfid` if only `/rfid/` is mounted
 	http.Handle("/rfid", rfidHandle)
+	http.Handle("/rfid/", rfidHandle)
 
 	// Create a logger for server
 	log := baseLog.WithField("package", "server")

--- a/test/general.js
+++ b/test/general.js
@@ -1,7 +1,6 @@
 /* eslint-env mocha */
 
-const { wait, getLogs, startDriver } = require('./utils')
-const rp = require('request-promise')
+const { wait, getJSON, startDriver } = require('./utils')
 const expect = require('chai').expect
 
 var driver
@@ -21,7 +20,7 @@ afterEach(() => {
 })
 
 it('Get message and version with HTTP get.', async () => {
-  return rp({uri: 'http://127.0.0.1:8382/', json: true})
+  return getJSON('http://127.0.0.1:8382')
   .then((response) => {
     expect(response).to.have.property('message').equal('Dividat Driver')
     expect(response).to.have.property('version')
@@ -37,7 +36,7 @@ it('Opening a second instance of the driver fails.', (done) => {
 })
 
 it('Get log entries from HTTP endpoint.', async () => {
-  const logs = await getLogs()
+  const logs = await getJSON('http://127.0.0.1:8382/log')
   expect(logs).to.be.an('array')
   expect(logs[0]).to.include({level: 'info', msg: 'Dividat Driver starting'})
 })

--- a/test/index.js
+++ b/test/index.js
@@ -6,3 +6,8 @@ describe('General functionality', () => {
 describe('Senso', () => {
   require('./senso')
 })
+
+
+describe('RFID', () => {
+  require('./rfid')
+})

--- a/test/rfid/index.js
+++ b/test/rfid/index.js
@@ -1,0 +1,34 @@
+/* eslint-env mocha */
+const { wait, startDriver, connectWS, expectEvent } = require('../utils')
+const expect = require('chai').expect
+const Promise = require('bluebird')
+
+// TESTS
+
+describe('Basic functionality', () => {
+  var driver
+  var rfid = {}
+
+  beforeEach(async () => {
+  // Start driver
+    var code = 0
+    driver = startDriver().on('exit', (c) => {
+      code = c
+    })
+  // Give driver 500ms to start up
+    await wait(500)
+    expect(code).to.be.equal(0)
+    driver.removeAllListeners()
+  })
+
+  afterEach(() => {
+    driver.kill()
+  })
+
+  it('Can connect to the RFID endpoint.', async function () {
+    this.timeout(500)
+
+    await connectWS('ws://127.0.0.1:8382/rfid')
+  })
+
+})

--- a/test/rfid/index.js
+++ b/test/rfid/index.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-const { wait, startDriver, connectWS, expectEvent } = require('../utils')
+const { wait, startDriver, connectWS, getJSON, expectEvent } = require('../utils')
 const expect = require('chai').expect
 const Promise = require('bluebird')
 
@@ -23,6 +23,13 @@ describe('Basic functionality', () => {
 
   afterEach(() => {
     driver.kill()
+  })
+
+  it('Can retrieve current reader list.', async function () {
+    this.timeout(500)
+
+    const response = await getJSON('http://127.0.0.1:8382/rfid/readers')
+    expect(response.readers).to.be.an('array')
   })
 
   it('Can connect to the RFID endpoint.', async function () {

--- a/test/utils.js
+++ b/test/utils.js
@@ -26,8 +26,8 @@ module.exports = {
     })
   },
 
-  getLogs: function () {
-    return rp({uri: 'http://127.0.0.1:8382/log', json: true})
+  getJSON: function (uri) {
+    return rp({uri: uri, json: true})
   },
 
   expectEvent: function (emitter, event, filter) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,4 +1,5 @@
 const { spawn } = require('child_process')
+const WebSocket = require('ws')
 const Promise = require('bluebird')
 const rp = require('request-promise')
 
@@ -13,6 +14,16 @@ module.exports = {
     return spawn('bin/dividat-driver')
     // useful for debugging:
     // return spawn('bin/dividat-driver', [], {stdio: 'inherit'})
+  },
+
+  connectWS: function (url) {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(url)
+      ws.on('open', () => {
+        ws.removeAllListeners()
+        resolve(ws)
+      }).on('error', reject)
+    })
   },
 
   getLogs: function () {


### PR DESCRIPTION
Uses the PC/SC APIs that are available as part of Windows and macOS, and through pcsclite on Linux.

### TODO

- [x] Currently loops to look for readers/cards, use blocking `GetStatusChange` function instead (Linux, Win)
- [x] Figure out how to select which reader(s) to use instead of using first detected
- [x] Integrate with musl changes
- [x] Make it work with Nix
  - [x] Add libpcsclite to dependencies (Linux)
  - [x] Teach nix-provisioned go on macOS where to find system frameworks
- [x] Make it play nicely with `winscard` (Windows)
  - [x] Retry after failed `EstablishContext` because Windows PC/SC service only comes online after reader present
  - [x] Prevent UID from being continuously transmitted if card left at reader
