### PR TITLE
Statical linking againg musl

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,6 +52,14 @@ Firefox, Safari and Edge not supported as they are not yet properly implementing
 
 Run the test suite with: `make test`.
 
+## Releasing
+
+Currently releases can only be made for Linux (from Linux). Builds on Linux are statically linked with [musl](https://www.musl-libc.org/).
+
+To create a release run: `make release`. You will need to be able to provide appropriate signing keys.
+
+To deploy a new release run: `make deploy`. This can only be done if you are on `master` or `develop` branch, have correctly tagged the revision and have AWS credentials set in your environment.
+
 ## Tools
 
 ### Data replayer

--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation {
       go_1_9
       dep
 
+      gcc
+      # Required for static linking on Linux
+      (if stdenv.isDarwin then null else musl)
+
       # node for tests
       nodejs-8_x
     ];


### PR DESCRIPTION
Unlike when compiling with "pure" go, cgo links dynamically (mostly to `glibc`, [1,2]). This usually works out ok, unless target host is using different version of `glibc` or it is in a completely different location (hey Nix!).

It is still possible to statically link with cgo, but it is a really bad idea to statically link `glibc` [3]. Enter [`musl`](https://www.musl-libc.org/) a standard library that was designed to be statically linked against.

These changes make builds on Linux statically link against musl. On Mac use `gcc` instead of Apple flavored `clang`.

For external C libraries (i.e. pcsc) this would require pcsc to be recompiled with musl.

[1] https://blog.hashbangbash.com/2014/04/linking-golang-statically/
[2] https://dominik.honnef.co/posts/2015/06/statically_compiled_go_programs__always__even_with_cgo__using_musl/
[3] https://tschottdorf.github.io/golang-static-linking-bug