### PR TITLE
Add Git to default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,6 +14,8 @@ stdenv.mkDerivation {
     buildInputs = [
       go_1_9
       dep
+      # Git is a de facto dependency of dep
+      git
 
       gcc
       # Required for static linking on Linux


### PR DESCRIPTION
`dep` requires git for fetching dependencies.