### PR TITLE
Improve RFID docs and reader compatibility

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Improvements to build system, in particular the crossbuild system for building releases.
+- Add support for listing SmartCard readers and subscribing to card UIDs
 
 ## [2.0.0] - 2018-04-09
 

--- a/src/dividat-driver/rfid/main.go
+++ b/src/dividat-driver/rfid/main.go
@@ -1,5 +1,36 @@
 package rfid
 
+/* Service for RFID tag touch-on events and listing connected readers.
+
+The purpose of this service is to notify subscribers of any RFID tags read by
+readers available to the host machine. The only information extracted from tags
+is their UID.
+
+In order to subscribe to RFID events, a client can open a WebSocket
+connection to
+
+    /rfid
+
+and will receive messages in case a new tag is read or the list of available
+readers changes.
+
+In addition, the current list is retrievable through simple GET request to
+
+    /rfid/readers
+
+The intended range of supported readers and tags includes all systems
+communicating according to ISO 7816-4, granted that the readers offer PC/SC
+support.
+
+The range of supported operating systems includes Windows and macOS, which come
+with bundled PC/SC services, as well as Linux systems running the libpcsclite
+service (pcscd).
+
+For details on the implementation and strategy of working with readers, see
+`pcsc.go`. The detection loop is only active if there are subscribers.
+
+*/
+
 import (
 	"context"
 	"encoding/json"

--- a/src/dividat-driver/rfid/pcsc.go
+++ b/src/dividat-driver/rfid/pcsc.go
@@ -187,7 +187,6 @@ func waitForCardActivity(haveBeenKilled *bool, log *logrus.Entry, scard_ctx *sca
 			_, err = card.Transmit(NO_BUZZ_APDU)
 			if err != nil {
 				log.WithError(err).Debug("Failed while transmitting silencer APDU.")
-				continue
 			}
 
 			// Request UID

--- a/src/dividat-driver/rfid/pcsc.go
+++ b/src/dividat-driver/rfid/pcsc.go
@@ -1,5 +1,25 @@
 package rfid
 
+/* Implements communication with ISO7816-4 compliant RFID readers via PC/SC.
+
+The basic assumption of this implementation is
+
+- we do not know the exact reader hardware connected in an installation, and
+- there are no readers connected to host machines other than those of interest
+  to our application.
+
+For this reason, the implementation simply queries all readers it finds for card
+UIDs continuously. Whenever a newly connected card responds to the request for
+its UID, the UID is passed on.
+
+Connection to the PC/SC service occurs through scard, a Go wrapper that
+harmonizes the PC/SC implementations of the various OS.
+
+This implementation has been tested with ACS ACR122U readers and Mifare 1K
+Classic tags.
+
+*/
+
 import (
 	"context"
 	"fmt"


### PR DESCRIPTION
Add more context on RFID service and make success of non-standard compliant reader command optional.