### PR TITLE
Increase Travis cache timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: nix
 cache:
+  timeout: 1200
   directories:
     - /nix
 script:


### PR DESCRIPTION
More investigation into the travis logs reveal:

> running `casher push` took longer than 180 seconds and has been aborted.
> You can extend the timeout with `cache.timeout`. See https://docs.travis-ci.com/user/caching/#Setting-the-timeout for details

I was expecting this error when loading cache content and not pushing it.

Timeout increased to 1200s.