### PR TITLE
Add a target to build without dep2nix, for homebrew.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,22 +36,28 @@ GO_LDFLAGS = -ldflags "$(STATIC_LINKING_LDFLAGS) -X dividat-driver/server.channe
 CODE_SIGNING_CERT ?= ./keys/codesign.p12
 CHECKSUM_SIGNING_CERT ?= ./keys/checksumsign.private.pem
 
+
+### Build from Nix ########################################
+.PHONY: nix-build
+nix-build: nix/deps.nix build
+
+
 ### Simple build ##########################################
 .PHONY: build
-build: nix/deps.nix
+build:
 	$(GOCROSS_OPTS) CC=$(CC) CXX=$(CXX) go build $(GO_LDFLAGS) -o $(OUT) $(SRC)
 
 
-### Test suite ##########################################
+### Test suite ############################################
 .PHONY: test
-test: build
+test: nix-build
 	npm install
 	npm test
 
 
 ### Helper to quickly run the driver
 .PHONY: run
-run: build
+run: nix-build
 	$(OUT)
 
 ### Helper to start the recorder

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,6 @@ CODE_SIGNING_CERT ?= ./keys/codesign.p12
 CHECKSUM_SIGNING_CERT ?= ./keys/checksumsign.private.pem
 
 
-### Build from Nix ########################################
-.PHONY: nix-build
-nix-build: nix/deps.nix build
-
-
 ### Simple build ##########################################
 .PHONY: build
 build:
@@ -50,14 +45,14 @@ build:
 
 ### Test suite ############################################
 .PHONY: test
-test: nix-build
+test:
 	npm install
 	npm test
 
 
 ### Helper to quickly run the driver
 .PHONY: run
-run: nix-build
+run:
 	$(OUT)
 
 ### Helper to start the recorder


### PR DESCRIPTION
Keeps the nix deps as default target, extracts the simple build as a target for homebrew build, for which we can't require dep2nix and who's randomly confused by nix/deps.nix timestamp at checkout.