### PR TITLE
Add Senso Flex bridge

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 with (import ./nix/nixpkgs.nix) {};
 
-buildGoPackage rec {
+buildGo112Package rec {
     name = "dividat-driver";
     goPackagePath = "dividat-driver";
 
@@ -10,7 +10,7 @@ buildGoPackage rec {
 
     buildInputs =
     [ 
-        go_1_9
+        go_1_12
         dep
         # Git is a de facto dependency of dep
         git

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -118,6 +118,15 @@
     };
   }
   {
+    goPackagePath  = "github.com/tarm/serial";
+    fetch = {
+      type = "git";
+      url = "https://github.com/tarm/serial";
+      rev =  "98f6abe2eb07edd42f6dfa2a934aea469acc29b7";
+      sha256 = "1yj4jiv2f3x3iawxdflrlmdan0k9xsbnccgc9yz658rmif1ag3pb";
+    };
+  }
+  {
     goPackagePath  = "golang.org/x/crypto";
     fetch = {
       type = "git";

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -19,6 +19,15 @@
     };
   }
   {
+    goPackagePath  = "github.com/creack/goselect";
+    fetch = {
+      type = "git";
+      url = "https://github.com/creack/goselect";
+      rev =  "f0c0d6863fbc64e624a609fafff94db2281647cd";
+      sha256 = "1aymhfvmz8666ng5bmm7c0gkgkfa6rl92dhapillg0kxzi9y53di";
+    };
+  }
+  {
     goPackagePath  = "github.com/cskr/pubsub";
     fetch = {
       type = "git";
@@ -86,8 +95,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/miekg/dns";
-      rev =  "a5852667e3c36e2e0b0a69ab43869e00e95aacdf";
-      sha256 = "0shjacfmsnrja06zsp39dnf5iyxmmpyrcpn6bkbp1ab4sallzpph";
+      rev =  "9884b9f4461219fe2640616077a9fb1fcb5a2124";
+      sha256 = "1j5d2kbp9nfp290xf80b8zfhyvrgb5dvc2ziwx1dfyjr134axn5c";
     };
   }
   {
@@ -118,12 +127,12 @@
     };
   }
   {
-    goPackagePath  = "github.com/tarm/serial";
+    goPackagePath  = "go.bug.st/serial";
     fetch = {
       type = "git";
-      url = "https://github.com/tarm/serial";
-      rev =  "98f6abe2eb07edd42f6dfa2a934aea469acc29b7";
-      sha256 = "1yj4jiv2f3x3iawxdflrlmdan0k9xsbnccgc9yz658rmif1ag3pb";
+      url = "https://github.com/bugst/go-serial.git";
+      rev =  "388e79306304ba8dee7df7ed971e0d12a7c57ca9";
+      sha256 = "080rx3y0jnymc6bymr175p8anpwsvngzl9518xbcckvsnq62zw32";
     };
   }
   {
@@ -131,8 +140,17 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/crypto";
-      rev =  "74369b46fc6756741c016591724fd1cb8e26845f";
-      sha256 = "0zfc540yrkyl85x9ps4d6s31qpazm4k8vmsy2r66wwaj2c0mw4z7";
+      rev =  "5ea612d1eb830b38bc4e914e37f55311eb58adce";
+      sha256 = "0mbhp35qad92a9fpcpc783jfrhhbgv9zsl0h98k10522blqhd9v5";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/mod";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/mod";
+      rev =  "6ce8bb3f08e0e47592fe93e007071d86dcf214bb";
+      sha256 = "0q4p41223d1xh4jmw9vmywjfi0jzn56gbidrwv5x1bzmx2qmj01n";
     };
   }
   {
@@ -140,8 +158,8 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/net";
-      rev =  "c73622c77280266305273cb545f54516ced95b93";
-      sha256 = "01zrk54nm3fpbaw9jbzlx0a8a0b4m8b47arypgwfajv22hmzbdgp";
+      rev =  "e18ecbb051101a46fc263334b127c89bc7bff7ea";
+      sha256 = "1vlq8mdscp7yfaa1lmyv03y5m4c2d67ydg2q1i6smkrxghn3zn3q";
     };
   }
   {
@@ -149,8 +167,35 @@
     fetch = {
       type = "git";
       url = "https://go.googlesource.com/sys";
-      rev =  "314a259e304ff91bd6985da2a7149bbf91237993";
-      sha256 = "0vya62c3kmhmqx6awlxx8hc84987xkym9rhs0q28vlhwk9kczdaa";
+      rev =  "b0d1d43c014ddb3da33b73f355a28f7b5bb0cb79";
+      sha256 = "1pvllhnympj4nvfgvc4gxrs9rv7j7ng3n5cpjigy1szsjx4ih7gs";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/term";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/term";
+      rev =  "6a3ed077a48de71621ad530f9078fffa0bc0ce32";
+      sha256 = "0xni8n3q2r9f6fk223b2c1702fvqmgz7vk6738asri3fwby583q5";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev =  "fe37c9e135b934191089b245ac29325091462508";
+      sha256 = "1asrm22kv5x891qkbpap8alg612k321jbs1akc0vwsan251gm507";
+    };
+  }
+  {
+    goPackagePath  = "golang.org/x/xerrors";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/xerrors";
+      rev =  "5ec99f83aff198f5fbd629d6c8d8eb38a04218ca";
+      sha256 = "1dbzc3gmf2haazpv7cgmv97rq40g2xzwbglc17vas8dwhgwgwrzb";
     };
   }
 ]

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,10 +1,94 @@
-# This pins the version of nixpkgs
 let
   _nixpkgs = import <nixpkgs> {};
 in 
-  import (_nixpkgs.fetchFromGitHub 
-  { owner = "NixOS"
-  ; repo = "nixpkgs"
-  ; rev = "18.09"
-  ; sha256 = "1ib96has10v5nr6bzf7v8kw7yzww8zanxgw2qi1ll1sbv6kj6zpd"; })
+{ crossSystem ? null, overlays ? [], config ? {} }:
+import
+  # This pins the version of nixpkgs
+  (_nixpkgs.fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs";
+    rev = "18.09";
+    sha256 = "1ib96has10v5nr6bzf7v8kw7yzww8zanxgw2qi1ll1sbv6kj6zpd";
+  })
+  {
+    crossSystem = crossSystem;
+
+    config = config;
+
+    overlays = overlays ++ [ (self: super:
+    {
+        # Backport Go 1.12.9 to old Nixpkgs
+        # Nixpkgs 19.03 and up seem to break crossbuilding with musl
+        # Based on https://github.com/NixOS/nixpkgs/blob/19.09/pkgs/development/compilers/go/1.12.nix
+        go_1_12 = super.go_1_11.overrideAttrs (old: rec {
+          version = "1.12.9";
+          name = "go-${version}";
+          src = self.fetchFromGitHub {
+            owner = "golang";
+            repo = "go";
+            rev = "go${version}";
+            sha256 = "1q316wgxhskwn5p622bcv81dhg93mads1591fppcf0dwyzpnl6wb";
+          };
+          patches = (
+            (self.lib.filter
+              (x: !(self.lib.hasSuffix "ssl-cert-file-1.9.patch" (builtins.toString x)) && !(self.lib.hasSuffix "remove-fhs-test-references.patch" (builtins.toString x)))
+              old.patches
+            ) ++ [
+              (self.fetchurl {
+                url = "https://github.com/NixOS/nixpkgs/raw/19.09/pkgs/development/compilers/go/ssl-cert-file-1.12.1.patch";
+                sha256 = "1645yrz36w35lnpalin4ygg39s7hpllamf81w1yr08g8div227f1";
+              })
+            ]
+          );
+          GOCACHE = null;
+          GO_BUILDER_NAME = "nix";
+          configurePhase = "";
+          postConfigure = ''
+            export GOCACHE=$TMPDIR/go-cache
+            # this is compiled into the binary
+            export GOROOT_FINAL=$out/share/go
+            export PATH=$(pwd)/bin:$PATH
+            # Independent from host/target, CC should produce code for the building system.
+            export CC=${self.buildPackages.stdenv.cc}/bin/cc
+            ulimit -a
+          '';
+          postBuild = ''
+            (cd src && ./make.bash)
+          '';
+          preInstall = ''
+            #rm -r pkg/{bootstrap,obj}
+            # Contains the wrong perl shebang when cross compiling,
+            # since it is not used for anything we can deleted as well.
+            rm src/regexp/syntax/make_perl_groups.pl
+          '' + (if (self.stdenv.buildPlatform != self.stdenv.hostPlatform) then ''
+            mv bin/*_*/* bin
+            rmdir bin/*_*
+            ${self.optionalString (!(self.GOHOSTARCH == self.GOARCH && self.GOOS == self.GOHOSTOS)) ''
+              rm -rf pkg/${self.GOHOSTOS}_${self.GOHOSTARCH} pkg/tool/${self.GOHOSTOS}_${self.GOHOSTARCH}
+            ''}
+          '' else if (self.stdenv.hostPlatform != self.stdenv.targetPlatform) then ''
+            rm -rf bin/*_*
+            ${self.optionalString (!(self.GOHOSTARCH == self.GOARCH && self.GOOS == self.GOHOSTOS)) ''
+              rm -rf pkg/${self.GOOS}_${self.GOARCH} pkg/tool/${self.GOOS}_${self.GOARCH}
+            ''}
+          '' else "");
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $GOROOT_FINAL
+            cp -a bin pkg src lib misc api doc $GOROOT_FINAL
+            ln -s $GOROOT_FINAL/bin $out/bin
+            runHook postInstall
+          '';
+        });
+
+        # GOCACHE can not be disabled in Go 1.12 but buildGoPackage definition hardcodes
+        # turning it off in NixOS 18.09.
+        buildGo112Package =
+          self.callPackage (self.fetchurl { url = "https://github.com/NixOS/nixpkgs/raw/19.09/pkgs/development/go-packages/generic/default.nix"; sha256 = "1bwkjbfxfym3v6z2zv0yrygpzck2cx63dpv46jil3py0yndaqrwa"; }) {
+            go = self.go_1_12;
+          };
+
+      }
+    ) ];
+}
 

--- a/src/dividat-driver/Gopkg.lock
+++ b/src/dividat-driver/Gopkg.lock
@@ -17,6 +17,14 @@
   revision = "e214231b295a8ea9479f11b70b35d5acf3556d9b"
 
 [[projects]]
+  digest = "1:b22880d2e72b84a64cc96db7e541bbf0a109f176375aea44eeb40b1f5c20d4b5"
+  name = "github.com/creack/goselect"
+  packages = ["."]
+  pruneopts = ""
+  revision = "f0c0d6863fbc64e624a609fafff94db2281647cd"
+  version = "v0.1.2"
+
+[[projects]]
   digest = "1:b4ea842b8118fa30a97605815a07f2126863087d4232cf5678dbd4da77ce4992"
   name = "github.com/cskr/pubsub"
   packages = ["."]
@@ -74,14 +82,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:105fe7dea39cca03fc09a82c562494c9afa4109acfd686052a33d4afed5012fa"
+  digest = "1:5db69e0e55ac416a2dd0863c2b08bde4453cb21003211da6f310da41ca3661c7"
   name = "github.com/miekg/dns"
-  packages = [
-    ".",
-    "internal/socket",
-  ]
+  packages = ["."]
   pruneopts = ""
-  revision = "a5852667e3c36e2e0b0a69ab43869e00e95aacdf"
+  revision = "9884b9f4461219fe2640616077a9fb1fcb5a2124"
+  version = "v1.1.40"
 
 [[projects]]
   digest = "1:29ec66aa13cb93e48d8f8506002f23001e76b7b5c96b30d7e58c40208bb1497d"
@@ -109,22 +115,39 @@
   revision = "884228600bc96c993ab12fb81ba78bf0c280e88a"
 
 [[projects]]
-  digest = "1:5a80808c3292ff8a8a7c340b8e4b4b4253eae8a6831fa3d506b232c8f5564ccf"
-  name = "github.com/tarm/serial"
-  packages = ["."]
+  digest = "1:6d6e66e78f7bf78c0b9655b8696c1c996c4b9a2edfe96d7ad6325d4d4725160c"
+  name = "go.bug.st/serial"
+  packages = [
+    ".",
+    "unixutils",
+  ]
   pruneopts = ""
-  revision = "98f6abe2eb07edd42f6dfa2a934aea469acc29b7"
+  revision = "388e79306304ba8dee7df7ed971e0d12a7c57ca9"
+  version = "v1.1.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:5462386895a322b94a79a5de7314310edbd5f4d15f851ae032f146b2c951b3de"
+  digest = "1:7a5d6bb15ac812fb9a875d4af643da0909e74a56148124511eb782ec848286cc"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = [
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "ssh/terminal",
+  ]
   pruneopts = ""
-  revision = "74369b46fc6756741c016591724fd1cb8e26845f"
+  revision = "5ea612d1eb830b38bc4e914e37f55311eb58adce"
 
 [[projects]]
-  digest = "1:e3fd71c3687fb1d263e491fc3bd9013858aeb30a6393fc9b77cbbdc37d0f9727"
+  digest = "1:d6772bc0ea7b951c26a690a8f162588eb6da26328b4aaf7398a0247f09d1dede"
+  name = "golang.org/x/mod"
+  packages = ["semver"]
+  pruneopts = ""
+  revision = "6ce8bb3f08e0e47592fe93e007071d86dcf214bb"
+  version = "v0.4.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:9a7bfb059471bb856114b1cf5ec7810a09387f41e7f5381d7e9e62100bd9a317"
   name = "golang.org/x/net"
   packages = [
     "bpf",
@@ -135,12 +158,16 @@
     "ipv6",
   ]
   pruneopts = ""
-  revision = "c73622c77280266305273cb545f54516ced95b93"
+  revision = "e18ecbb051101a46fc263334b127c89bc7bff7ea"
 
 [[projects]]
-  digest = "1:e9f555036bb1a2f61074131371313348581fa1b643c0e5f8c0a436bf7ce6db69"
+  branch = "master"
+  digest = "1:a736268f2fd035992c85768bde2ac164804b53ddf8757d96fc7e9dac9cf9eca4"
   name = "golang.org/x/sys"
   packages = [
+    "execabs",
+    "internal/unsafeheader",
+    "plan9",
     "unix",
     "windows",
     "windows/registry",
@@ -149,7 +176,48 @@
     "windows/svc/mgr",
   ]
   pruneopts = ""
-  revision = "314a259e304ff91bd6985da2a7149bbf91237993"
+  revision = "b0d1d43c014ddb3da33b73f355a28f7b5bb0cb79"
+
+[[projects]]
+  branch = "master"
+  digest = "1:a67aa4df296910aef0b97509d88b4a962e42624a2f2101c21c5674275844edf8"
+  name = "golang.org/x/term"
+  packages = ["."]
+  pruneopts = ""
+  revision = "6a3ed077a48de71621ad530f9078fffa0bc0ce32"
+
+[[projects]]
+  digest = "1:dfc8eb0346c4d8e0e32e26c906bf35edd8365a2bd441a2ac17f0d22579f433c8"
+  name = "golang.org/x/tools"
+  packages = [
+    "go/ast/astutil",
+    "go/gcexportdata",
+    "go/internal/gcimporter",
+    "go/internal/packagesdriver",
+    "go/packages",
+    "go/types/typeutil",
+    "internal/event",
+    "internal/event/core",
+    "internal/event/keys",
+    "internal/event/label",
+    "internal/gocommand",
+    "internal/packagesinternal",
+    "internal/typesinternal",
+  ]
+  pruneopts = ""
+  revision = "fe37c9e135b934191089b245ac29325091462508"
+  version = "v0.1.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:a5a7a1a9560c0eb1f8b32c40da2e71bd2a05b9ff9e1ea294461c7dbe0d24c6bc"
+  name = "golang.org/x/xerrors"
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = ""
+  revision = "5ec99f83aff198f5fbd629d6c8d8eb38a04218ca"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -167,7 +235,7 @@
     "github.com/pin/tftp",
     "github.com/sirupsen/logrus",
     "github.com/streadway/amqp",
-    "github.com/tarm/serial",
+    "go.bug.st/serial",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/src/dividat-driver/Gopkg.lock
+++ b/src/dividat-driver/Gopkg.lock
@@ -109,6 +109,13 @@
   revision = "884228600bc96c993ab12fb81ba78bf0c280e88a"
 
 [[projects]]
+  digest = "1:5a80808c3292ff8a8a7c340b8e4b4b4253eae8a6831fa3d506b232c8f5564ccf"
+  name = "github.com/tarm/serial"
+  packages = ["."]
+  pruneopts = ""
+  revision = "98f6abe2eb07edd42f6dfa2a934aea469acc29b7"
+
+[[projects]]
   branch = "master"
   digest = "1:5462386895a322b94a79a5de7314310edbd5f4d15f851ae032f146b2c951b3de"
   name = "golang.org/x/crypto"
@@ -160,6 +167,7 @@
     "github.com/pin/tftp",
     "github.com/sirupsen/logrus",
     "github.com/streadway/amqp",
+    "github.com/tarm/serial",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/src/dividat-driver/Gopkg.toml
+++ b/src/dividat-driver/Gopkg.toml
@@ -69,3 +69,7 @@ ignored = ["server","senso"]
 [[constraint]]
   name = "github.com/streadway/amqp"
   revision = "884228600bc96c993ab12fb81ba78bf0c280e88a"
+
+[[constraint]]
+  name = "github.com/tarm/serial"
+  revision = "98f6abe2eb07edd42f6dfa2a934aea469acc29b7"

--- a/src/dividat-driver/Gopkg.toml
+++ b/src/dividat-driver/Gopkg.toml
@@ -71,5 +71,5 @@ ignored = ["server","senso"]
   revision = "884228600bc96c993ab12fb81ba78bf0c280e88a"
 
 [[constraint]]
-  name = "github.com/tarm/serial"
-  revision = "98f6abe2eb07edd42f6dfa2a934aea469acc29b7"
+  name = "go.bug.st/serial"
+  version = "=1.1.3"

--- a/src/dividat-driver/flex/main.go
+++ b/src/dividat-driver/flex/main.go
@@ -127,6 +127,9 @@ func scanAndConnectSerial(ctx context.Context, logger *logrus.Entry, onReceive f
 	}
 }
 
+
+// Serial communication
+
 type ReaderState int
 
 const (
@@ -155,8 +158,9 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 		StopBits:    serial.Stop1,
 	}
 
-	logger.WithField("address", serialName).Info("Attempting to connect with serial port.")
+	START_MEASUREMENT_CMD := []byte{'S', '\n'}
 
+	logger.WithField("address", serialName).Info("Attempting to connect with serial port.")
 	port, err := serial.OpenPort(config)
 	if err != nil {
 		logger.WithField("config", config).WithField("error", err).Info("Failed to open connection to serial port.")
@@ -164,7 +168,7 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 	}
 	defer port.Close()
 
-	_, err = port.Write([]byte{'S', '\n'})
+	_, err = port.Write(START_MEASUREMENT_CMD)
 	if err != nil {
 		logger.WithField("error", err).Info("Failed to write start message to serial port.")
 		port.Close()
@@ -225,7 +229,7 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 
 					// Get ready for next set and request it
 					state = WAITING_FOR_HEADER
-					_, err = port.Write([]byte{'S', '\n'})
+					_, err = port.Write(START_MEASUREMENT_CMD)
 					if err != nil {
 						logger.WithField("error", err).Info("Failed to write poll message to serial port.")
 						port.Close()

--- a/src/dividat-driver/flex/main.go
+++ b/src/dividat-driver/flex/main.go
@@ -1,0 +1,154 @@
+package flex
+
+import (
+	"context"
+	"sync"
+
+	"fmt"
+	"bufio"
+	"io"
+	"time"
+
+	"github.com/cskr/pubsub"
+	"github.com/sirupsen/logrus"
+	"github.com/tarm/serial"
+)
+
+// Handle for managing SensingTex connection
+type Handle struct {
+	broker *pubsub.PubSub
+
+	Address *string
+
+	ctx context.Context
+
+	cancelCurrentConnection context.CancelFunc
+	connectionChangeMutex   *sync.Mutex
+
+	log *logrus.Entry
+}
+
+// New returns an initialized handler
+func New(ctx context.Context, log *logrus.Entry) *Handle {
+	handle := Handle{}
+
+	handle.ctx = ctx
+
+	handle.log = log
+
+	handle.connectionChangeMutex = &sync.Mutex{}
+
+	// PubSub broker
+	handle.broker = pubsub.New(32)
+
+	// Clean up
+	go func() {
+		<-ctx.Done()
+		handle.broker.Shutdown()
+	}()
+
+	return &handle
+}
+
+// Connect to a Senso, will create TCP connections to control and data ports
+func (handle *Handle) Connect(address string) {
+
+	// Only allow one connection change at a time
+	handle.connectionChangeMutex.Lock()
+	defer handle.connectionChangeMutex.Unlock()
+
+	// disconnect current connection first
+	handle.Disconnect()
+
+	// set address in handle
+	handle.Address = &address
+
+	// Create a child context for a new connection. This allows an individual connection (attempt) to be cancelled without restarting the whole handler
+	ctx, cancel := context.WithCancel(handle.ctx)
+
+	handle.log.WithField("address", address).Info("Attempting to connect with serial port.")
+
+	onReceive := func(data []byte) {
+		handle.broker.TryPub(data, "rx")
+	}
+
+	go connectSerial(ctx, handle.log, address, onReceive)
+
+	handle.cancelCurrentConnection = cancel
+}
+
+// Disconnect from current connection
+func (handle *Handle) Disconnect() {
+	if handle.cancelCurrentConnection != nil {
+		handle.log.Info("Disconnecting from serial port.")
+		handle.cancelCurrentConnection()
+		handle.Address = nil
+	}
+}
+
+type ReaderState int
+
+const (
+	WaitingForFirstHeader ReaderState = iota
+	HeaderStarted
+	ExpectingHeaderEnd
+	ReadingRowData
+	ReachedRowEnd
+	UnexpectedByte
+)
+
+func connectSerial(ctx context.Context, baseLogger *logrus.Entry, address string, onReceive func([]byte)) {
+	config := &serial.Config{
+		Name: "/dev/ttyAMA0",
+		Baud: 115200,
+		ReadTimeout: 100 * time.Millisecond,
+		Size: 8,
+		Parity: serial.ParityNone,
+		StopBits: serial.Stop1,
+	}
+	fmt.Println(config)
+
+	serialHandle, err := serial.OpenPort(config)
+        if err != nil {
+                // TODO
+                panic(err)
+        }
+
+	_, err = serialHandle.Write([]byte{'S', '\n'})
+	if err != nil {
+		panic(err)
+	}
+
+        reader := bufio.NewReader(serialHandle)
+	state := WaitingForFirstHeader
+
+        var buff []byte
+        for {
+                input, err := reader.ReadByte()
+                // TODO Handle other errors
+                if err != nil && err == io.EOF {
+                        break
+                }
+
+                if state == WaitingForFirstHeader && input == 0x48 {
+			state = HeaderStarted
+                } else if state == ReachedRowEnd && input == 0x48 {
+			state = HeaderStarted
+			fmt.Println()
+			fmt.Printf("%x\n", buff)
+			onReceive(buff)
+                        buff = []byte{}
+		} else if state == HeaderStarted && input == 0x00 {
+			state = ExpectingHeaderEnd
+		} else if state == ExpectingHeaderEnd && input == 0x0A {
+			state = ReachedRowEnd
+		} else if state == ReadingRowData && input == 0x0A {
+			state = ReachedRowEnd
+		} else if state == ReachedRowEnd && input == 0x4D {
+			state = ReadingRowData
+			buff = append(buff, input)
+		} else if state == ReadingRowData {
+			buff = append(buff, input)
+		}
+        }
+}

--- a/src/dividat-driver/flex/main.go
+++ b/src/dividat-driver/flex/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"sync"
 
-	"fmt"
 	"bufio"
+	"fmt"
 	"io"
 	"time"
 
@@ -17,8 +17,6 @@ import (
 // Handle for managing SensingTex connection
 type Handle struct {
 	broker *pubsub.PubSub
-
-	Address *string
 
 	ctx context.Context
 
@@ -50,8 +48,8 @@ func New(ctx context.Context, log *logrus.Entry) *Handle {
 	return &handle
 }
 
-// Connect to a Senso, will create TCP connections to control and data ports
-func (handle *Handle) Connect(address string) {
+// Connect to device
+func (handle *Handle) Connect() {
 
 	// Only allow one connection change at a time
 	handle.connectionChangeMutex.Lock()
@@ -60,19 +58,19 @@ func (handle *Handle) Connect(address string) {
 	// disconnect current connection first
 	handle.Disconnect()
 
-	// set address in handle
-	handle.Address = &address
-
 	// Create a child context for a new connection. This allows an individual connection (attempt) to be cancelled without restarting the whole handler
 	ctx, cancel := context.WithCancel(handle.ctx)
 
-	handle.log.WithField("address", address).Info("Attempting to connect with serial port.")
+	// TODO [knuton] Probably want to discover the name of the serial port
+	serialName := "/dev/ttyACM0"
+
+	handle.log.WithField("address", serialName).Info("Attempting to connect with serial port.")
 
 	onReceive := func(data []byte) {
 		handle.broker.TryPub(data, "rx")
 	}
 
-	go connectSerial(ctx, handle.log, address, onReceive)
+	go connectSerial(ctx, handle.log, serialName, onReceive)
 
 	handle.cancelCurrentConnection = cancel
 }
@@ -82,89 +80,109 @@ func (handle *Handle) Disconnect() {
 	if handle.cancelCurrentConnection != nil {
 		handle.log.Info("Disconnecting from serial port.")
 		handle.cancelCurrentConnection()
-		handle.Address = nil
 	}
 }
 
 type ReaderState int
 
 const (
+	// Init
 	WaitingForFirstHeader ReaderState = iota
+	// Header
 	HeaderStarted
 	ExpectingHeaderEnd
+	// Data row
 	RowStarted
 	WaitingForRowIndex
 	ReadingRowData
 	ReachedRowEnd
+	// Error state
 	UnexpectedByte
 )
 
-func connectSerial(ctx context.Context, baseLogger *logrus.Entry, address string, onReceive func([]byte)) {
+func connectSerial(ctx context.Context, baseLogger *logrus.Entry, serialName string, onReceive func([]byte)) {
 	config := &serial.Config{
-		Name: "/dev/ttyACM0",
-		Baud: 115200,
+		Name:        serialName,
+		Baud:        460800,
 		ReadTimeout: 100 * time.Millisecond,
-		Size: 8,
-		Parity: serial.ParityNone,
-		StopBits: serial.Stop1,
-	}
-	fmt.Println(config)
-
-	serialHandle, err := serial.OpenPort(config)
-        if err != nil {
-                // TODO
-                panic(err)
-        }
-
-	_, err = serialHandle.Write([]byte{'S', '\n'})
-	if err != nil {
-		panic(err)
+		Size:        8,
+		Parity:      serial.ParityNone,
+		StopBits:    serial.Stop1,
 	}
 
-        reader := bufio.NewReader(serialHandle)
-	state := WaitingForFirstHeader
-	bytesLeftInRow := 0
+	for {
+		// TODO Check whether we have been killed before re-entering loop
 
-        var buff []byte
-        for {
-                input, err := reader.ReadByte()
-                // TODO Handle other errors
-                if err != nil && err == io.EOF {
-                        break
-                }
-
-		switch {
-		case state == WaitingForFirstHeader && input == 0x48:
-			state = HeaderStarted
-		case state == ReachedRowEnd && input == 0x48:
-			state = HeaderStarted
-			fmt.Println()
-			fmt.Printf("%x\n", buff)
-			onReceive(buff)
-                        buff = []byte{}
-		case state == HeaderStarted && input == 0x00:
-			state = ExpectingHeaderEnd
-		case state == ExpectingHeaderEnd && input == 0x0A:
-			state = ReachedRowEnd
-		case state == ReadingRowData && bytesLeftInRow > 0:
-			bytesLeftInRow = bytesLeftInRow - 1
-			buff = append(buff, input)
-		case state == ReadingRowData && bytesLeftInRow == 0 && input == 0x0A:
-			state = ReachedRowEnd
-			buff = append(buff, input)
-		case state == ReachedRowEnd && input == 0x4D:
-			state = RowStarted
-			buff = append(buff, input)
-		case state == RowStarted:
-			state = WaitingForRowIndex
-			// 2 bytes per sample
-			bytesLeftInRow = int(input) * 2
-			buff = append(buff, input)
-		case state == WaitingForRowIndex:
-			state = ReadingRowData
-			buff = append(buff, input)
-		case state == ReadingRowData:
-			buff = append(buff, input)
+		port, err := serial.OpenPort(config)
+		if err != nil {
+			baseLogger.WithField("config", config).WithField("error", err).Info("Failed to open connection to serial port.")
+			time.Sleep(2 * time.Second)
+			continue
 		}
-        }
+
+		_, err = port.Write([]byte{'S', '\n'})
+		if err != nil {
+			baseLogger.WithField("error", err).Info("Failed to write start message to serial port.")
+			port.Close()
+			continue
+		}
+
+		reader := bufio.NewReader(port)
+		state := WaitingForFirstHeader
+		bytesLeftInRow := 0
+
+		var buff []byte
+		for {
+			// TODO Check whether we have been killed before reading next byte
+
+			input, err := reader.ReadByte()
+			// TODO Handle other errors
+			if err != nil && err == io.EOF {
+				break
+			}
+
+			switch {
+			case state == WaitingForFirstHeader && input == 0x48:
+				state = HeaderStarted
+			case state == ReachedRowEnd && input == 0x48:
+				state = HeaderStarted
+				fmt.Println()
+				fmt.Printf("%x\n", buff)
+				onReceive(buff)
+				buff = []byte{}
+			case state == UnexpectedByte && input == 0x48:
+				// Recover from error state when a new header is seen
+				buff = []byte{}
+				bytesLeftInRow = 0
+				state = HeaderStarted
+			case state == HeaderStarted && input == 0x00:
+				state = ExpectingHeaderEnd
+			case state == ExpectingHeaderEnd && input == 0x0A:
+				state = ReachedRowEnd
+			case state == ReadingRowData && bytesLeftInRow > 0:
+				bytesLeftInRow = bytesLeftInRow - 1
+				buff = append(buff, input)
+			case state == ReadingRowData && bytesLeftInRow == 0 && input == 0x0A:
+				state = ReachedRowEnd
+				buff = append(buff, input)
+			case state == ReachedRowEnd && input == 0x4D:
+				state = RowStarted
+				buff = append(buff, input)
+			case state == RowStarted:
+				state = WaitingForRowIndex
+				// 2 bytes per sample
+				bytesLeftInRow = int(input) * 2
+				buff = append(buff, input)
+			case state == WaitingForRowIndex:
+				state = ReadingRowData
+				buff = append(buff, input)
+			case state == ReadingRowData:
+				buff = append(buff, input)
+			default:
+				state = UnexpectedByte
+			}
+		}
+
+		port.Close()
+	}
 }

--- a/src/dividat-driver/flex/main.go
+++ b/src/dividat-driver/flex/main.go
@@ -14,9 +14,9 @@ The functionality of this module is as follows:
 */
 
 import (
+	"bufio"
 	"context"
 	"encoding/binary"
-	"bufio"
 	"strings"
 	"time"
 
@@ -33,7 +33,7 @@ type Handle struct {
 	ctx context.Context
 
 	cancelCurrentConnection context.CancelFunc
-	subscriberCount int
+	subscriberCount         int
 
 	log *logrus.Entry
 }
@@ -42,8 +42,8 @@ type Handle struct {
 func New(ctx context.Context, log *logrus.Entry) *Handle {
 	handle := Handle{
 		broker: pubsub.New(32),
-		ctx: ctx,
-		log: log,
+		ctx:    ctx,
+		log:    log,
 	}
 
 	// Clean up
@@ -131,7 +131,6 @@ func isFlexLike(port *enumerator.PortDetails) bool {
 	return vendorId == "16C0"
 }
 
-
 // Serial communication
 
 type ReaderState int
@@ -148,8 +147,8 @@ const (
 
 const (
 	HEADER_START_MARKER = 'N'
-	BODY_START_MARKER = 'P'
-	BYTES_PER_SAMPLE = 4
+	BODY_START_MARKER   = 'P'
+	BYTES_PER_SAMPLE    = 4
 )
 
 // Actually attempt to connect to an individual serial port and pipe its signal into the callback, summarizing
@@ -204,7 +203,7 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 			state = HEADER_START
 		case state == HEADER_START && input == '\n':
 			state = HEADER_READ_LENGTH_MSB
-                case state == HEADER_READ_LENGTH_MSB:
+		case state == HEADER_READ_LENGTH_MSB:
 			// The number of measurements in each set may vary and is
 			// given as two consecutive bytes (big-endian).
 			msb := input
@@ -212,14 +211,14 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 			if err != nil {
 				return
 			}
-			samplesLeftInSet = int(binary.BigEndian.Uint16([]byte{msb,lsb}))
+			samplesLeftInSet = int(binary.BigEndian.Uint16([]byte{msb, lsb}))
 			state = WAITING_FOR_BODY
 		case state == WAITING_FOR_BODY && input == BODY_START_MARKER:
 			state = BODY_START
 		case state == BODY_START && input == '\n':
 			state = BODY_READ_SAMPLE
 			bytesLeftInSample = BYTES_PER_SAMPLE
-                case state == BODY_READ_SAMPLE:
+		case state == BODY_READ_SAMPLE:
 			buff = append(buff, input)
 			bytesLeftInSample = bytesLeftInSample - 1
 

--- a/src/dividat-driver/flex/main.go
+++ b/src/dividat-driver/flex/main.go
@@ -7,6 +7,9 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"path"
+	"strings"
 	"time"
 
 	"github.com/cskr/pubsub"
@@ -61,16 +64,11 @@ func (handle *Handle) Connect() {
 	// Create a child context for a new connection. This allows an individual connection (attempt) to be cancelled without restarting the whole handler
 	ctx, cancel := context.WithCancel(handle.ctx)
 
-	// TODO [knuton] Probably want to discover the name of the serial port
-	serialName := "/dev/ttyACM0"
-
-	handle.log.WithField("address", serialName).Info("Attempting to connect with serial port.")
-
 	onReceive := func(data []byte) {
 		handle.broker.TryPub(data, "rx")
 	}
 
-	go connectSerial(ctx, handle.log, serialName, onReceive)
+	go listeningLoop(ctx, handle.log, onReceive)
 
 	handle.cancelCurrentConnection = cancel
 }
@@ -80,6 +78,47 @@ func (handle *Handle) Disconnect() {
 	if handle.cancelCurrentConnection != nil {
 		handle.log.Info("Disconnecting from serial port.")
 		handle.cancelCurrentConnection()
+	}
+}
+
+// Keep looking for serial devices and connect to them when found, sending signals into the
+// callback.
+func listeningLoop(ctx context.Context, baseLogger *logrus.Entry, onReceive func([]byte)) {
+	for {
+		findAndConnectSerial(ctx, baseLogger, onReceive)
+
+		// TODO Check whether to die
+
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// One pass of browsing for serial devices and trying to connect to them turn by turn, first
+// successful connection wins.
+//
+// NOTE Portability of serial device detection has not been tested. This is a prototype
+// implementation intended for Linux systems.
+func findAndConnectSerial(ctx context.Context, baseLogger *logrus.Entry, onReceive func([]byte)) {
+	deviceFileFolder := "/dev"
+
+	files, err := ioutil.ReadDir(deviceFileFolder)
+	if err != nil {
+		baseLogger.WithField("error", err).Info("Could not list serial devices.")
+		return
+	}
+
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+
+		if !strings.HasPrefix(f.Name(), "ttyACM") {
+			continue
+		}
+
+		connectSerial(ctx, baseLogger, path.Join(deviceFileFolder, f.Name()), onReceive)
+
+		// TODO check whether to die
 	}
 }
 
@@ -100,6 +139,8 @@ const (
 	UnexpectedByte
 )
 
+// Actually attempt to connect to an individual serial port and pipe its signal into the callback, summarizing
+// package units into a buffer.
 func connectSerial(ctx context.Context, baseLogger *logrus.Entry, serialName string, onReceive func([]byte)) {
 	config := &serial.Config{
 		Name:        serialName,
@@ -110,79 +151,77 @@ func connectSerial(ctx context.Context, baseLogger *logrus.Entry, serialName str
 		StopBits:    serial.Stop1,
 	}
 
-	for {
-		// TODO Check whether we have been killed before re-entering loop
+	baseLogger.WithField("address", serialName).Info("Attempting to connect with serial port.")
 
-		port, err := serial.OpenPort(config)
-		if err != nil {
-			baseLogger.WithField("config", config).WithField("error", err).Info("Failed to open connection to serial port.")
-			time.Sleep(2 * time.Second)
-			continue
-		}
-
-		_, err = port.Write([]byte{'S', '\n'})
-		if err != nil {
-			baseLogger.WithField("error", err).Info("Failed to write start message to serial port.")
-			port.Close()
-			continue
-		}
-
-		reader := bufio.NewReader(port)
-		state := WaitingForFirstHeader
-		bytesLeftInRow := 0
-
-		var buff []byte
-		for {
-			// TODO Check whether we have been killed before reading next byte
-
-			input, err := reader.ReadByte()
-			// TODO Handle other errors
-			if err != nil && err == io.EOF {
-				break
-			}
-
-			switch {
-			case state == WaitingForFirstHeader && input == 0x48:
-				state = HeaderStarted
-			case state == ReachedRowEnd && input == 0x48:
-				state = HeaderStarted
-				fmt.Println()
-				fmt.Printf("%x\n", buff)
-				onReceive(buff)
-				buff = []byte{}
-			case state == UnexpectedByte && input == 0x48:
-				// Recover from error state when a new header is seen
-				buff = []byte{}
-				bytesLeftInRow = 0
-				state = HeaderStarted
-			case state == HeaderStarted && input == 0x00:
-				state = ExpectingHeaderEnd
-			case state == ExpectingHeaderEnd && input == 0x0A:
-				state = ReachedRowEnd
-			case state == ReadingRowData && bytesLeftInRow > 0:
-				bytesLeftInRow = bytesLeftInRow - 1
-				buff = append(buff, input)
-			case state == ReadingRowData && bytesLeftInRow == 0 && input == 0x0A:
-				state = ReachedRowEnd
-				buff = append(buff, input)
-			case state == ReachedRowEnd && input == 0x4D:
-				state = RowStarted
-				buff = append(buff, input)
-			case state == RowStarted:
-				state = WaitingForRowIndex
-				// 2 bytes per sample
-				bytesLeftInRow = int(input) * 2
-				buff = append(buff, input)
-			case state == WaitingForRowIndex:
-				state = ReadingRowData
-				buff = append(buff, input)
-			case state == ReadingRowData:
-				buff = append(buff, input)
-			default:
-				state = UnexpectedByte
-			}
-		}
-
-		port.Close()
+	port, err := serial.OpenPort(config)
+	if err != nil {
+		baseLogger.WithField("config", config).WithField("error", err).Info("Failed to open connection to serial port.")
+		return
 	}
+	defer port.Close()
+
+	_, err = port.Write([]byte{'S', '\n'})
+	if err != nil {
+		baseLogger.WithField("error", err).Info("Failed to write start message to serial port.")
+		port.Close()
+		return
+	}
+
+	reader := bufio.NewReader(port)
+	state := WaitingForFirstHeader
+	bytesLeftInRow := 0
+
+	var buff []byte
+	for {
+		// TODO Check whether we have been killed before reading next byte
+
+		input, err := reader.ReadByte()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			continue
+		}
+
+		switch {
+		case state == WaitingForFirstHeader && input == 0x48:
+			state = HeaderStarted
+		case state == ReachedRowEnd && input == 0x48:
+			state = HeaderStarted
+			fmt.Println()
+			fmt.Printf("%x\n", buff)
+			onReceive(buff)
+			buff = []byte{}
+		case state == UnexpectedByte && input == 0x48:
+			// Recover from error state when a new header is seen
+			buff = []byte{}
+			bytesLeftInRow = 0
+			state = HeaderStarted
+		case state == HeaderStarted && input == 0x00:
+			state = ExpectingHeaderEnd
+		case state == ExpectingHeaderEnd && input == 0x0A:
+			state = ReachedRowEnd
+		case state == ReadingRowData && bytesLeftInRow > 0:
+			bytesLeftInRow = bytesLeftInRow - 1
+			buff = append(buff, input)
+		case state == ReadingRowData && bytesLeftInRow == 0 && input == 0x0A:
+			state = ReachedRowEnd
+			buff = append(buff, input)
+		case state == ReachedRowEnd && input == 0x4D:
+			state = RowStarted
+			buff = append(buff, input)
+		case state == RowStarted:
+			state = WaitingForRowIndex
+			// 2 bytes per sample
+			bytesLeftInRow = int(input) * 2
+			buff = append(buff, input)
+		case state == WaitingForRowIndex:
+			state = ReadingRowData
+			buff = append(buff, input)
+		case state == ReadingRowData:
+			buff = append(buff, input)
+		default:
+			state = UnexpectedByte
+		}
+	}
+
 }

--- a/src/dividat-driver/flex/main.go
+++ b/src/dividat-driver/flex/main.go
@@ -149,8 +149,7 @@ const (
 func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string, onReceive func([]byte)) {
 	config := &serial.Config{
 		Name:        serialName,
-		Baud:        460800,
-		ReadTimeout: 100 * time.Millisecond,
+		Baud:        921600,
 		Size:        8,
 		Parity:      serial.ParityNone,
 		StopBits:    serial.Stop1,
@@ -224,8 +223,14 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 					onReceive(buff)
 					buff = []byte{}
 
-					// Get ready for next set
+					// Get ready for next set and request it
 					state = WAITING_FOR_HEADER
+					_, err = port.Write([]byte{'S', '\n'})
+					if err != nil {
+						logger.WithField("error", err).Info("Failed to write poll message to serial port.")
+						port.Close()
+						return
+					}
 				} else {
 					// Start next point
 					bytesLeftInPoint = 4

--- a/src/dividat-driver/flex/main.go
+++ b/src/dividat-driver/flex/main.go
@@ -150,6 +150,7 @@ const (
 const (
 	HEADER_START_MARKER = 'N'
 	BODY_START_MARKER = 'P'
+	BYTES_PER_SAMPLE = 4
 )
 
 // Actually attempt to connect to an individual serial port and pipe its signal into the callback, summarizing
@@ -222,7 +223,7 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 			state = BODY_START
 		case state == BODY_START && input == '\n':
 			state = BODY_READ_SAMPLE
-			bytesLeftInSample = 4
+			bytesLeftInSample = BYTES_PER_SAMPLE
                 case state == BODY_READ_SAMPLE:
 			buff = append(buff, input)
 			bytesLeftInSample = bytesLeftInSample - 1
@@ -244,7 +245,7 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 					}
 				} else {
 					// Start next point
-					bytesLeftInSample = 4
+					bytesLeftInSample = BYTES_PER_SAMPLE
 				}
 			}
 		case state == UNEXPECTED_BYTE && input == HEADER_START_MARKER:

--- a/src/dividat-driver/flex/main.go
+++ b/src/dividat-driver/flex/main.go
@@ -1,5 +1,21 @@
 package flex
 
+/* Connects to Senso Flex devices through a serial connection and combines serial data into measurement sets.
+
+This helps establish an indirect WebSocket connection to receive a stream of samples from the device.
+
+The functionality of this module is as follows:
+
+- While connected, scan for serial devices that look like a potential Flex device
+- Connect to suitable serial devices and start polling for measurements
+- Minimally parse incoming data to determine start and end of a measurement
+- Send each complete measurement set to client as a binary package
+
+
+NOTE At the moment this functionality is limited to Linux and macOS systems.
+
+*/
+
 import (
 	"context"
 	"encoding/binary"

--- a/src/dividat-driver/flex/main.go
+++ b/src/dividat-driver/flex/main.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/binary"
 	"bufio"
-	"io"
 	"strings"
 	"time"
 
@@ -195,10 +194,8 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 		}
 
 		input, err := reader.ReadByte()
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			continue
+		if err != nil {
+			return
 		}
 
 		// Finite State Machine for parsing byte stream
@@ -212,10 +209,8 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 			// given as two consecutive bytes (big-endian).
 			msb := input
 			lsb, err := reader.ReadByte()
-			if err == io.EOF {
-				break
-			} else if err != nil {
-				continue
+			if err != nil {
+				return
 			}
 			samplesLeftInSet = int(binary.BigEndian.Uint16([]byte{msb,lsb}))
 			state = WAITING_FOR_BODY

--- a/src/dividat-driver/flex/main.go
+++ b/src/dividat-driver/flex/main.go
@@ -170,12 +170,14 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 		logger.WithField("config", mode).WithField("error", err).Info("Failed to open connection to serial port.")
 		return
 	}
-	defer port.Close()
+	defer func() {
+		logger.WithField("name", serialName).Info("Disconnecting from serial port.")
+		port.Close()
+	}()
 
 	_, err = port.Write(START_MEASUREMENT_CMD)
 	if err != nil {
 		logger.WithField("error", err).Info("Failed to write start message to serial port.")
-		port.Close()
 		return
 	}
 
@@ -188,7 +190,6 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 	for {
 		// Terminate if we were cancelled
 		if ctx.Err() != nil {
-			logger.WithField("name", serialName).Info("Disconnecting from serial port.")
 			return
 		}
 
@@ -239,7 +240,6 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 					_, err = port.Write(START_MEASUREMENT_CMD)
 					if err != nil {
 						logger.WithField("error", err).Info("Failed to write poll message to serial port.")
-						port.Close()
 						return
 					}
 				} else {

--- a/src/dividat-driver/flex/websocket.go
+++ b/src/dividat-driver/flex/websocket.go
@@ -53,18 +53,16 @@ func (handle *Handle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create channels with data received from SensingTex controller
-	rx := handle.broker.Sub("rx")
+	rx := handle.broker.Sub("flex-rx")
 
 	// send data from device
 	go rx_data_loop(ctx, rx, sendBinary)
 
 	// Helper function to close the connection
 	close := func() {
-		// Unsubscribe from broker
 		handle.broker.Unsub(rx)
 
-		// Stop serial connection
-		handle.Disconnect()
+		handle.DeregisterSubscriber()
 
 		// Cancel the context
 		cancel()

--- a/src/dividat-driver/flex/websocket.go
+++ b/src/dividat-driver/flex/websocket.go
@@ -55,13 +55,16 @@ func (handle *Handle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Create channels with data received from SensingTex controller
 	rx := handle.broker.Sub("rx")
 
-	// send data from Control and Data channel
+	// send data from device
 	go rx_data_loop(ctx, rx, sendBinary)
 
 	// Helper function to close the connection
 	close := func() {
 		// Unsubscribe from broker
 		handle.broker.Unsub(rx)
+
+		// Stop serial connection
+		handle.Disconnect()
 
 		// Cancel the context
 		cancel()
@@ -71,6 +74,9 @@ func (handle *Handle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		log.Info("Websocket connection closed")
 	}
+
+	// Start connecting to devices
+	handle.Connect()
 
 	// Main loop for the WebSocket connection
 	go func() {

--- a/src/dividat-driver/flex/websocket.go
+++ b/src/dividat-driver/flex/websocket.go
@@ -1,0 +1,123 @@
+package flex
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/sirupsen/logrus"
+)
+
+// WEBSOCKET PROTOCOL
+
+// Implement net/http Handler interface
+func (handle *Handle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	// Set up logger
+	var log = handle.log.WithFields(logrus.Fields{
+		"clientAddress": r.RemoteAddr,
+		"userAgent":     r.UserAgent(),
+	})
+
+	// Update to WebSocket
+	conn, err := webSocketUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.WithError(err).Error("Could not upgrade connection to WebSocket.")
+		http.Error(w, "WebSocket upgrade error", http.StatusBadRequest)
+		return
+	}
+
+	log.Info("WebSocket connection opened")
+
+	// Create a mutex for writing to WebSocket (connection supports only one concurrent reader and one concurrent writer (https://godoc.org/github.com/gorilla/websocket#hdr-Concurrency))
+	writeMutex := sync.Mutex{}
+
+	// Create a context for this WebSocket connection
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Send binary data up the WebSocket
+	sendBinary := func(data []byte) error {
+		writeMutex.Lock()
+		conn.SetWriteDeadline(time.Now().Add(50 * time.Millisecond))
+		err := conn.WriteMessage(websocket.BinaryMessage, data)
+		writeMutex.Unlock()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
+				log.WithError(err).Error("WebSocket error")
+			}
+			return err
+		}
+		return nil
+	}
+
+	// Create channels with data received from SensingTex controller
+	rx := handle.broker.Sub("rx")
+
+	// send data from Control and Data channel
+	go rx_data_loop(ctx, rx, sendBinary)
+
+	// Helper function to close the connection
+	close := func() {
+		// Unsubscribe from broker
+		handle.broker.Unsub(rx)
+
+		// Cancel the context
+		cancel()
+
+		// Close websocket connection
+		conn.Close()
+
+		log.Info("Websocket connection closed")
+	}
+
+	// Main loop for the WebSocket connection
+	go func() {
+		defer close()
+		for {
+
+			_, _, err := conn.ReadMessage()
+			if err != nil {
+				if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
+					log.WithError(err).Error("WebSocket error")
+				}
+				return
+			}
+
+		}
+	}()
+
+}
+
+// HELPERS
+
+// rx_data_loop reads data from SensingTex and forwards it up the WebSocket
+func rx_data_loop(ctx context.Context, rx chan interface{}, send func([]byte) error) {
+	var err error
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case i := <-rx:
+			data, ok := i.([]byte)
+			if ok {
+				err = send(data)
+			}
+		}
+
+		if err != nil {
+			return
+		}
+	}
+}
+
+// Helper to upgrade http to WebSocket
+var webSocketUpgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+}

--- a/src/dividat-driver/server/main.go
+++ b/src/dividat-driver/server/main.go
@@ -62,7 +62,7 @@ func Start(logger *logrus.Logger) context.CancelFunc {
 	// Setup SensingTex reader
 	flexHandle := flex.New(ctx, baseLog.WithField("package", "flex"))
 	http.Handle("/flex", flexHandle)
-	flexHandle.Connect("foo")
+	flexHandle.Connect()
 
 	// Setup RFID scanner
 	rfidHandle := rfid.NewHandle(ctx, baseLog.WithField("package", "rfid"))

--- a/src/dividat-driver/server/main.go
+++ b/src/dividat-driver/server/main.go
@@ -62,7 +62,6 @@ func Start(logger *logrus.Logger) context.CancelFunc {
 	// Setup SensingTex reader
 	flexHandle := flex.New(ctx, baseLog.WithField("package", "flex"))
 	http.Handle("/flex", flexHandle)
-	flexHandle.Connect()
 
 	// Setup RFID scanner
 	rfidHandle := rfid.NewHandle(ctx, baseLog.WithField("package", "rfid"))

--- a/src/dividat-driver/server/main.go
+++ b/src/dividat-driver/server/main.go
@@ -10,6 +10,7 @@ import (
 	"dividat-driver/logging"
 	"dividat-driver/rfid"
 	"dividat-driver/senso"
+	"dividat-driver/flex"
 	"dividat-driver/update"
 )
 
@@ -57,6 +58,11 @@ func Start(logger *logrus.Logger) context.CancelFunc {
 	// Setup Senso
 	sensoHandle := senso.New(ctx, baseLog.WithField("package", "senso"))
 	http.Handle("/senso", sensoHandle)
+
+	// Setup SensingTex reader
+	flexHandle := flex.New(ctx, baseLog.WithField("package", "flex"))
+	http.Handle("/flex", flexHandle)
+	flexHandle.Connect("foo")
 
 	// Setup RFID scanner
 	rfidHandle := rfid.NewHandle(ctx, baseLog.WithField("package", "rfid"))


### PR DESCRIPTION
This adds a new WebSocket bridge for Flex devices. The basic idea is the same as for Senso and RFID, we close the hardware gap for the web application, in this case relaying serial device input via WebSocket messages.

The branch includes commits that capture the developmental stages of the Flex prototypes:

- 18766d6: First 4x4 developer kit (finger-sized)
- 8aa4b0b: 16x16 sensor developer kit
- 82f099f: First custom built mats (push-based protocol)
- 589dc9a: Second and up to current custom built mats (pull-based protocol)

Further iterations on the device protocol are expected, but I think this is stable and robust enough to be integrated.

### Testing

Unfortunately there isn't much to test without a Flex device. I tried to provide a replayable mock device using [umockdev](https://github.com/martinpitt/umockdev), but older versions I tried didn't capture anything, while versions 0.13.0 and up segfault when the tty device is accessed. I'd like to modernize the driver package to use a current version of Go and it might be worth trying again then.