### PR TITLE
Add Private Network Access headers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,10 @@
 - Tool to record data from Senso
 - Command-line interface to update firmware on Senso via Ethernet
 
+### Changed
+
+- Limit permissible CORS origins
+
 ### Removed
 
 - Remove centralized log sink

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add a new bridge for Senso Flex devices
+- Add CORS response headers for private network access
 - Tool to record data from Senso
 - Command-line interface to update firmware on Senso via Ethernet
 

--- a/src/dividat-driver/logging/server.go
+++ b/src/dividat-driver/logging/server.go
@@ -88,7 +88,6 @@ func (logServer *LogServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer logServer.mutex.RUnlock()
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8") // normal header
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	// first collect entries in slice so that we can intersperse with ",". See also: https://www.happyassassin.net/2017/09/07/a-modest-proposal/
 	entries := make([][]byte, 0, bufferSize)

--- a/src/dividat-driver/rfid/main.go
+++ b/src/dividat-driver/rfid/main.go
@@ -153,7 +153,6 @@ func (handle *Handle) ServerReaderList(w http.ResponseWriter, r *http.Request) {
 	}{
 		Readers: handle.knownReaders,
 	})
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(readersJson)
 }

--- a/src/dividat-driver/server/main.go
+++ b/src/dividat-driver/server/main.go
@@ -113,6 +113,7 @@ func corsHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if len(r.Header["Origin"]) == 1 && isPermissibleOrigin(r.Header["Origin"][0]) {
 			w.Header().Set("Access-Control-Allow-Origin", r.Header["Origin"][0])
+			w.Header().Set("Access-Control-Allow-Private-Network", "true")
 		}
 
 		if r.Method == "OPTIONS" {


### PR DESCRIPTION
Add headers for private network access, systematize CORS header application and limit permissible origins.

Details for the changes are in the commits.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
