### PR TITLE
Add replay tools for Senso Flex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,12 @@ run: build
 ### Helper to start the recorder
 .PHONY: record
 record:
-	@go run src/dividat-driver/recorder/main.go
+	@go run src/dividat-driver/recorder/main.go ws://localhost:8382/senso
 
+### Helper to start the recorder for Flex
+.PHONY: record-flex
+record-flex:
+	@go run src/dividat-driver/recorder/main.go ws://localhost:8382/flex
 
 ### Cross compilation #####################################
 LINUX_BIN = bin/dividat-driver-linux-amd64

--- a/Readme.md
+++ b/Readme.md
@@ -71,7 +71,13 @@ To be able to connect to the driver from within a web app delivered over HTTPS, 
 
 ### Data recorder
 
+#### Senso data
+
 Data from Senso can be recorded using the [`recorder`](src/dividat-driver/recorder). Start it with `make record > foo.dat`. The created recording can be used by the replayer.
+
+#### Senso Flex data
+
+Like Senso data, but with `make record-flex`.
 
 ### Data replayer
 
@@ -84,3 +90,11 @@ To replay an other recording: `npm run replay -- rec/simple.dat`
 To change the replay speed: `npm run replay -- --speed=0.5 rec/simple.dat`
 
 To run without looping: `npm run replay -- --once`
+
+#### Senso replay
+
+The Senso replayer will appear as a Senso network device, so both driver and replayer should be running at the same time.
+
+#### Senso Flex replay
+
+The Senso Flex replayer (`npm run replay-flex`) supports the same parameters as the Senso replayer. It mocks the driver with respect to the `/flex` WebSocket resource, so the driver can not be running at the same time.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "test": "mocha --exit test/index.js",
-    "replay": "node tools/replay/"
+    "replay": "node tools/replay/",
+    "replay-flex": "node tools/replay-flex/"
   },
   "dependencies": {
     "bluebird": "^3.7.2",

--- a/src/dividat-driver/recorder/main.go
+++ b/src/dividat-driver/recorder/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"os/signal"
@@ -15,11 +16,11 @@ func main() {
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)
 
-	u := url.URL{Scheme: "ws", Host: "localhost:8382", Path: "/senso"}
+	u := parseUrl()
 
 	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Could not record from '%s': %s", u.String(), err)
 	}
 	defer c.Close()
 
@@ -56,4 +57,15 @@ func main() {
 			return
 		}
 	}
+}
+
+func parseUrl() url.URL {
+	if (len(os.Args) < 2) {
+		log.Fatal("Expected the WebSocket URL to record from as a parameter")
+	}
+	u, err := url.Parse(os.Args[1])
+	if err != nil {
+		log.Fatalf("Malformed WebSocket URL: %s", err)
+	}
+	return *u
 }

--- a/tools/replay-flex/index.js
+++ b/tools/replay-flex/index.js
@@ -1,0 +1,59 @@
+// Mock the driver at localhost:8382 to replay Senso Flex package recordings
+
+const argv = require('minimist')(process.argv.slice(2))
+const fs = require('fs')
+const split = require('binary-split')
+const websocket = require('ws')
+const EventEmitter = require('events')
+
+var recFile = argv['_'].pop() || 'rec/zero.dat'
+let speedFactor = 1/(parseFloat(argv['speed']) || 1)
+let loop = !argv['once']
+
+// Create a never ending stream of data
+function Replayer (recFile) {
+  var emitter = new EventEmitter()
+
+  function createStream () {
+    var stream = new fs.createReadStream(recFile).pipe(split())
+
+    stream.on('data', (data) => {
+      stream.pause()
+
+      var items = data.toString().split(',')
+      var msg
+      var timeout
+      if (items.length === 2) {
+        msg = items[1]
+        timeout = items[0]
+      } else {
+        msg = items[0]
+        timeout = 20
+      }
+      var buf = Buffer.from(msg, 'base64')
+      emitter.emit('data', buf)
+
+      setTimeout(() => {
+        stream.resume()
+      }, timeout * speedFactor)
+    }).on('end', () => {
+      if (loop) {
+        console.log('End of the record stream, looping.')
+        createStream()
+      } else {
+        console.log('End of the record stream, exiting.')
+        process.exit(0)
+      }
+    })
+  }
+  createStream()
+  return emitter
+}
+
+const wss = new websocket.Server({ port: 8382 })
+
+wss.on('connection', function connection(ws) {
+  const dataStream = Replayer(recFile)
+
+  dataStream.on('data', (data) => ws.send(data))
+})


### PR DESCRIPTION
Generalizes the recorder tool to record from any WebSocket address, and introduces a Flex-specific replay tool that mocks the `/flex` resource of the driver.

Here's a dump recorded with the recorder: [center.zip](https://github.com/dividat/driver/files/9601614/center.zip)
