### PR TITLE
Add client-to-device communication for Flex (v4)

### DIFF
--- a/src/dividat-driver/flex/websocket.go
+++ b/src/dividat-driver/flex/websocket.go
@@ -81,14 +81,16 @@ func (handle *Handle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		defer close()
 		for {
 
-			_, _, err := conn.ReadMessage()
+			messageType, msg, err := conn.ReadMessage()
 			if err != nil {
 				if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
 					log.WithError(err).Error("WebSocket error")
 				}
 				return
 			}
-
+			if messageType == websocket.BinaryMessage {
+				handle.broker.TryPub(msg, "flex-tx")
+			}
 		}
 	}()
 


### PR DESCRIPTION
Makes the driver forward binary commands received on the `/flex` WebSocket connection to the serial device it is connected to.

In this version the driver is hard-coded to send the 8 bit mode command upon connecting, as the protocol isn't self-documenting to allow for parsing of byte streams without knowledge of sample bitdepth. This could be made configurable at the price of some added complexity if needed, but hardcoding seems the most economical solution while we have no intention to use anything but 8 bit mode.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
