### PR TITLE
Make firmware update command optimistic

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [UNRELEASED]
+
+### Changed
+
+- Let firmware update command look for bootloader if no Senso in regular mode is found
+
 ## [2.3.0] - 2022-10-01
 
 ### Added

--- a/src/dividat-driver/firmware/main.go
+++ b/src/dividat-driver/firmware/main.go
@@ -45,6 +45,8 @@ func Command(flags []string) {
 	err = Update(context.Background(), file, deviceSerial, configuredAddr)
 	if err != nil {
 		fmt.Println(err.Error())
+		fmt.Println()
+		fmt.Println("Update failed. Try turning the Senso off and on, waiting for 30 seconds and then running this update tool again.")
 		os.Exit(1)
 	}
 }

--- a/src/dividat-driver/firmware/main.go
+++ b/src/dividat-driver/firmware/main.go
@@ -108,7 +108,7 @@ func Update(parentCtx context.Context, image io.Reader, deviceSerial *string, co
 		fail = err
 		return
 	}
-	fmt.Println("✓ Firmware transmitted to Senso.")
+	fmt.Println("Success! Firmware transmitted to Senso.")
 	return
 }
 


### PR DESCRIPTION
Instead of giving up immediately when we can not detect a Senso in
regular mode or can not send the DFU command, keep going and try to
discover a Senso in bootloader mode that we may be able to transmit the
firmware image to.

This helps us recover from a scenario where a Senso ended up in
bootloader mode but did not receive the firmware due to some network
issue.

Sensos up to at least firmware 3.8.1 do not restart into the regular
mode once brought to bootloader mode, so leaving them there without
means for recovery is problematic.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
