### PR TITLE
Drop support for connection to Senso on port 55568

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Let firmware update command look for bootloader if no Senso in regular mode is found
+- Drop support for connecting to Sensos on port 55568
 
 ## [2.3.0] - 2022-10-01
 

--- a/src/dividat-driver/senso/main.go
+++ b/src/dividat-driver/senso/main.go
@@ -3,8 +3,6 @@ package senso
 import (
 	"context"
 	"sync"
-	"time"
-
 	"github.com/cskr/pubsub"
 	"github.com/sirupsen/logrus"
 )
@@ -67,8 +65,6 @@ func (handle *Handle) Connect(address string) {
 		handle.broker.TryPub(data, "rx")
 	}
 
-	go connectTCP(ctx, handle.log.WithField("channel", "data"), address+":55568", handle.broker.Sub("noTx"), onReceive)
-	time.Sleep(1000 * time.Millisecond)
 	go connectTCP(ctx, handle.log.WithField("channel", "control"), address+":55567", handle.broker.Sub("tx"), onReceive)
 
 	handle.cancelCurrentConnection = cancel


### PR DESCRIPTION
Referring to a previous discussion we had:

> Sensos with FW this old should be paired with an outdated PC, not PlayOS, so would not get a driver update we release through PlayOS.

This removes a lot of noise from the logs.

## Checklist

-   ~[ ] Changelog updated~
-   ~[ ] Code documented~
