### PR TITLE
Protect WebSocket endpoints from untrusted origin requests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Deny WebSocket connections from unknown origins
 - Let firmware update command look for bootloader if no Senso in regular mode is found
 - Update build system and development environment
 

--- a/src/dividat-driver/flex/websocket.go
+++ b/src/dividat-driver/flex/websocket.go
@@ -124,6 +124,7 @@ var webSocketUpgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
 	CheckOrigin: func(r *http.Request) bool {
+		// Check is performed by top-level HTTP middleware, and not repeated here.
 		return true
 	},
 }

--- a/src/dividat-driver/senso/websocket.go
+++ b/src/dividat-driver/senso/websocket.go
@@ -323,6 +323,7 @@ var webSocketUpgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
 	CheckOrigin: func(r *http.Request) bool {
+		// Check is performed by top-level HTTP middleware, and not repeated here.
 		return true
 	},
 }

--- a/test/cors.js
+++ b/test/cors.js
@@ -1,0 +1,89 @@
+/* eslint-env mocha */
+
+const { wait, getJSON, startDriver, connectWS } = require('./utils')
+const expect = require('chai').expect
+
+const httpEndpoints = [
+  'http://127.0.0.1:8382',
+  'http://127.0.0.1:8382/log',
+  'http://127.0.0.1:8382/rfid/readers'
+]
+
+const wsEndpoints = [
+  'ws://127.0.0.1:8382/senso',
+  'ws://127.0.0.1:8382/flex'
+]
+
+const permissibleOrigins = [ 'https://test-origin.xyz', 'http://127.0.0.1:8000' ]
+const untrustedOrigin = 'https://foreign-origin.xyz'
+
+let driver
+
+beforeEach(async () => {
+  let code = 0
+  driver = startDriver(...permissibleOrigins.flatMap(origin => [ '--permissible-origin', origin ])).on('exit', (c) => {
+    code = c
+  })
+  await wait(500)
+  expect(code).to.be.equal(0)
+  driver.removeAllListeners()
+})
+
+afterEach(() => {
+  driver.kill()
+})
+
+// No `Origin` header
+
+it('can make HTTP requests with no origin set', async () => {
+  return Promise.all(httpEndpoints.map(url =>
+    fetch(url).then((response) => { expect(response.status, `GET ${url}`).to.equal(200) })
+  ))
+})
+
+it('can connect to WebSocket endpoints with no origin set', async () => {
+  return Promise.all(wsEndpoints.map(async (url) => {
+    let connected = await connectWS(url).then(_ => true).catch(_ => false)
+    expect(connected, `WS ${url}`).to.be.true
+  }))
+})
+
+// Known `Origin` header
+
+it('can make HTTP requests with known origin set', async () => {
+  return Promise.all(httpEndpoints.flatMap(url =>
+    permissibleOrigins.map(origin =>
+      fetch(url, { headers: { Origin: origin } }).then((response) => {
+        expect(response.status, `GET ${url} (Origin: ${origin})`).to.equal(200)
+        expect(response.headers.get('Access-Control-Allow-Origin'), `Access-Control-Allow-Origin ${url}`).to.equal(origin)
+        expect(response.headers.get('Access-Control-Allow-Private-Network'), `Access-Control-Allow-Private-Network ${url}`).to.equal('true')
+      })
+    )
+  ))
+})
+
+it('can connect to WebSocket endpoints with known origin set', async () => {
+  return Promise.all(wsEndpoints.flatMap(url =>
+    permissibleOrigins.map(async (origin) => {
+      let connected = await connectWS(url, { headers: { Origin: origin } }).then(_ => true).catch(_ => false)
+      expect(connected, `WS ${url} (Origin: ${origin})`).to.be.true
+    })
+  ))
+})
+
+// Unknown `Origin` header
+
+it('can not make HTTP requests with unknown origin set', async () => {
+  return Promise.all(httpEndpoints.map(url =>
+    fetch(url, { headers: { Origin: untrustedOrigin } }).then((response) => {
+      expect(response.status, `GET ${url}`).to.equal(403)
+    })
+  ))
+})
+
+it('can not connect to WebSocket endpoints with unknown origin set', async () => {
+  return Promise.all(wsEndpoints.map(async (url) => {
+    let connected = await connectWS(url, { headers: { Origin: untrustedOrigin } }).then(_ => true).catch(_ => false)
+    expect(connected, `WS ${url}`).to.be.false
+  }))
+})

--- a/test/index.js
+++ b/test/index.js
@@ -3,10 +3,13 @@ describe('General functionality', () => {
   require('./general')
 })
 
+describe('CORS and PNA protection', () => {
+  require('./cors')
+})
+
 describe('Senso', () => {
   require('./senso')
 })
-
 
 describe('RFID', () => {
   require('./rfid')

--- a/test/utils.js
+++ b/test/utils.js
@@ -10,15 +10,15 @@ module.exports = {
     })
   },
 
-  startDriver: function () {
-    return spawn('bin/dividat-driver')
+  startDriver: function (...args) {
+    return spawn('bin/dividat-driver', args)
     // useful for debugging:
     // return spawn('bin/dividat-driver', [], {stdio: 'inherit'})
   },
 
-  connectWS: function (url) {
+  connectWS: function (url, opts) {
     return new Promise((resolve, reject) => {
-      const ws = new WebSocket(url)
+      const ws = new WebSocket(url, opts)
       ws.on('open', () => {
         ws.removeAllListeners()
         resolve(ws)


### PR DESCRIPTION
We previously added support for adding Private Network Access and CORS headers only for a whitelist of permissible origins. This protects browser users running the driver locally against abuse from third-party websites, which could make HTTP requests to the driver at the loopback address.

This commit extends this protection to WebSocket endpoints, for which browsers do not currently perform pre-flight requests. We therefore explicitly deny all requests from unknown origins.

This change prepares for the driver gaining the capability of triggering firmware updates in connected devices (#127).

## Checklist

-   [x] Changelog updated
-   [x] Code documented
