### PR TITLE
Add mode field in replayer

### DIFF
--- a/tools/replay/index.js
+++ b/tools/replay/index.js
@@ -115,7 +115,7 @@ const dataStream = Replayer(recFile)
 // Advertise Senso via mDNS
 bonjour.publish({
   name: 'Senso data replayer',
-  txt: {ser_no: profile.serial_number},
+  txt: {ser_no: profile.serial_number, mode: 'Application'},
   type: 'sensoControl',
   port: '55567'})
 


### PR DESCRIPTION
All modern Sensos send this field and we are making the driver expect it.

@krksgbr I know you have something in the pipeline, but this seems like an easy immediate fix until then.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
