### PR TITLE
Fix potential index out of range error

### DIFF
--- a/src/dividat-driver/service/main.go
+++ b/src/dividat-driver/service/main.go
@@ -82,7 +82,7 @@ func scanForType(ctx context.Context, t ServiceType, results chan<- Service, wg 
 					entriesWithoutSerial++
 				}
 				var address string
-				if entry.AddrIPv4[0] != nil {
+				if len(entry.AddrIPv4) > 0 {
 					address = entry.AddrIPv4[0].String()
 				} else {
 					continue


### PR DESCRIPTION
Being a go noob, I misunderstood how to safely check if an element is present in a slice.
Trying to access `slice[0]` when the slice is empty doesn't evaluate to `nil`, but causes an index out of range error.
We haven't noticed this because the condition never came about, but now it did while running some tests with the Senso mocking tool I've been working on.

## Checklist

-   ~[ ] Changelog updated~
-   ~[ ] Code documented~
