### PR TITLE
Increase discovery timeout to 120 s in firmware updater

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## [UNRELEASED]
 
+### Changed
+
+- Allow up to 2 minutes for device discovery in firmware updater
+
 ## [2.4.0] - 2024-05-22
 
 ### Added

--- a/src/dividat-driver/firmware/main.go
+++ b/src/dividat-driver/firmware/main.go
@@ -30,7 +30,7 @@ import (
 
 const tftpPort = "69"
 const controllerPort = "55567"
-const discoveryTimeout = 60 * time.Second
+const discoveryTimeout = 120 * time.Second
 
 type OnProgress func(msg string)
 


### PR DESCRIPTION
There are at least three instances (albeit all at the same customer location) of firmware update initially failing due to discovery timeout while waiting for the bootloader to appear. In all cases, the update completed when retried a brief while later, as the bootloader had finished startup and announcing itself via mDNS, plus that being picked up by the client.

Based on the timestamps of my photos from the site, there must have been around 20 seconds between the initial failure and eventual bootloader discoverability. So 90 seconds timeout may be enough, but it is not worth trading unnecessary update failures for occasional 30 seconds of unsuccessful waiting. Giving two full minutes for discovery.

Fixes #141.

## Checklist

-   [x] Changelog updated
-   [x] Code documented
