### PR TITLE
Add bitdepth command and bitdepth=12 support to Flex driver

### DIFF
--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -22,6 +22,9 @@ mkShell
     libtool
     flex
     pkg-config
+
+    # tycmd executable for resetting controller in driver
+    tytools
   ]
   ++ lib.optional stdenv.isLinux pcsclite
   ++ lib.optional stdenv.isDarwin pkgs.darwin.apple_sdk.frameworks.PCSC;


### PR DESCRIPTION
See commit messages for more details. They are to be squashed, but keeping them separate so you can see the initial "naive" implementation I did and then the horrendous hack I had to resort to.

If you want to try it with Play, use the [flex-v5 branch](https://github.com/yfyf/diviapps/tree/flex-v5)