### PR TITLE
Bring driver-version flag in line with repo conventions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -122,4 +122,4 @@ The Senso Flex replayer (`npm run replay-flex`) supports the same parameters as 
 
 It mocks the driver with respect to the `/flex` WebSocket resource and the `/` metadata HTTP route, so the real driver can not be running at the same time.
 
-You can control the mocked driver version via the `--driverVersion` flag.
+You can control the mocked driver version via the `--driver-version` flag.

--- a/tools/replay-flex/index.js
+++ b/tools/replay-flex/index.js
@@ -9,7 +9,7 @@ const EventEmitter = require('events')
 
 var recFile = argv['_'].pop() || 'rec/flex/zero.dat'
 let speedFactor = 1/(parseFloat(argv['speed']) || 1)
-let driverVersion = argv['driverVersion'] || "9.9.9-REPLAY"
+let driverVersion = argv['driver-version'] || "9.9.9-REPLAY"
 let loop = !argv['once']
 
 // Create a never ending stream of data


### PR DESCRIPTION
I confused myself for a moment because of the camel casing. Admittedly I should have just read the docs, but I also think repo/project conventions are useful.


## Checklist

-   [x] Changelog updated
-   [x] Code documented
