### PR TITLE
Reset serial port input buffer after (re-)opening

### DIFF
--- a/src/dividat-driver/flex/main.go
+++ b/src/dividat-driver/flex/main.go
@@ -196,6 +196,7 @@ func connectSerial(ctx context.Context, logger *logrus.Entry, serialName string,
 		logger.WithField("config", mode).WithField("error", err).Info("Failed to open connection to serial port.")
 		return
 	}
+	port.ResetInputBuffer() // flush any unread data buffered by the OS
 
 	readerCtx, readerCtxCancel := context.WithCancel(ctx)
 


### PR DESCRIPTION
This prevents the reader incorrectly interpreting buffered input from an earlier connection that might have been set up with a different bitdepth.

The bug is reproducible ~1/3 times by reloading Play on Chromium while running with a v5 profile - the Flex settings page shows Play is connected to the Driver, but is not receiving any data. With this patch, I cannot reproduce neither with plain reloads, nor with "close" and "reopen" tab as I discovered it originally. Tested on both Chromium and Firefox for 20+ times.

The sequence of events:

- Play/Driver connect to Flex mat
- Play is running with V5 profile, 12bit mode
- Flex firmware gets configured with 12bit
- Driver/Play start receiving frames
- Play tab is closed and the Websocket is closed
- Driver closes the serial port
- Play is re-opened
- Driver connects to Flex, sets 8bit mode by default, reader is started
- There is buffered unread 12bit data in the serial port, reader (configured with 8bit) gets confused about the frame sizes and gets stuck waiting for input/samples
- Since the reader is stuck, Play does not receive any frames from the driver's websocket, so it does not send profile commands (and hence bitdepth is not changed and reader is not reset)
- Deadlock!

In theory, this bug was always possible, since nothing ensured that we fully consumed the data in the port earlier, but of course now it's more likely to happen, since the reader misinterprets the data.

Side-note: would be good to setup a simple serial port recorder/replayer to turn these scenarios into integration tests.

## Checklist

-   [ ] Changelog updated
-   [ ] Code documented
