### PR TITLE
Add macOS crossbuild targets and create GH releases for each tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,80 @@
+name: Release Tag
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: DeterminateSystems/magic-nix-cache-action@v11
+      - run: nix develop --command make crossbuild_mac
+      - run: nix develop --command make crossbuild_mac_bundles
+      - name: 'Upload Artifacts'
+        uses: actions/upload-artifact@v4
+        id: upload
+        with:
+          name: binaries-macos
+          path: bin/*
+
+  build-others:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: DeterminateSystems/magic-nix-cache-action@v11
+      - run: nix develop --command make crossbuild
+      - name: 'Upload Artifacts'
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-others
+          path: bin/*
+
+  release:
+    needs: [build-macos, build-others]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: binaries-*
+          path: artifacts/
+          merge-multiple: true
+
+      - run: find artifacts/ -type f
+
+      - run: ls -lh artifacts/
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create \
+            --verify-tag \
+            --notes-from-tag \
+            "$GITHUB_REF_NAME" \
+            $(find artifacts/ -maxdepth 1 -type f)

--- a/Readme.md
+++ b/Readme.md
@@ -44,29 +44,54 @@ A default nix shell (defined in `nix/devShell.nix`) provides all necessary depen
 
 Releases are built as statically linked binaries for windows and linux using the cross compilation toolchain provided by nix. The toolchain is provided by nix shells defined in [crossBuild.nix](nix/crossBuild.nix). Building the binaries can be done by running `make crossbuild` from the default shell.
 
-Existing release targets:
+Existing official release targets:
 
 - Linux: x86_64 (statically linked with [musl](https://www.musl-libc.org/))
 - Windows: x86_64
 
-There are also build shells for macOS binaries, but these are not hooked into `make crossbuild` as currently they only work on macOS.
+There are also build targets for macOS binaries, but these are not hooked into `make crossbuild` as currently they only work on macOS.
+
 To build the macOS binaries:
 
 ```sh
-export VERSION=$(git describe --always HEAD)
-
-# Build for aarch64 / arm64 / Apple silicon
-nix develop .\#crossBuild.darwin.aarch64 --command ./build.sh -v "$VERSION" -i src/dividat-driver/main.go -o ./bin/dividat-driver-darwin-arm64
-
-# Build for x86_64 / amd64 / Intel
-nix develop .\#crossBuild.darwin.x86_64 --command ./build.sh -v "$VERSION" -i src/dividat-driver/main.go -o ./bin/dividat-driver-darwin-amd64
+make crossbuild_mac
 ```
+
+This will build binaries for Intel (amd64) and Silicon/M-series Macs (arm64).
+Note: recent macOS versions prevent running unsigned arm64 binaries!
+
+For non-technical-user convenience, we also provide macOS app bundles, which can
+be built using:
+
+```sh
+make crossbuild_mac_bundles
+```
+
+All tagged versions of Driver also get automatically crossbuilt and published as
+Github releases for convenience. See the [Release page for
+details](https://github.com/dividat/driver/releases). **Binaries in Github
+releases are not meant for official distribution/installations.**
 
 ### Deploying
 
 To deploy a new release run: `make deploy`. This can only be done if you have correctly tagged the revision and have AWS credentials set in your environment.
 
 ## Installation
+
+### macOS
+
+The Driver can be manually run as macOS App for testing/demo purposes.
+
+Latest versions are available in the [release page](https://github.com/dividat/driver/releases).
+
+For recent M-series macOS computers (Apple Silicon), download the arm64 variant
+called: `DividatDriver-arm64.app.zip`.
+
+For older macOS computers (Intel-based), download the adm64 variant called
+`DividatDriver-amd64.app.zip`.
+
+They apps freake-signed (not notorized), so you have to [manually allow
+execution in macOS Settings](https://support.apple.com/en-us/102445#openanyway).
 
 ### Windows
 

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "
+http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>driver</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.dividat.driver</string>
+    <key>CFBundleName</key>
+    <string>DividatDriver</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleExecutable</key>
+    <string>launcher</string>
+</dict>
+</plist>

--- a/macos/launcher
+++ b/macos/launcher
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+open -a Terminal "$DIR/driver"


### PR DESCRIPTION
This was motivated by the need to provide easily runnable binaries to non-tech users for demo purposes and to automate the process so that the binaries are available whenever needed.

It now kinda shadows the "official" release process, but that's maybe tolerable.

Binaries verified to work by @terezka and Joris/Bujar.

Demo release run: https://github.com/yfyf/driver/actions/runs/16054095507
Demo release page: https://github.com/yfyf/driver/releases/tag/2.6.1-testFINAL

## Checklist

-   [ ] Changelog updated
-   [X] Code documented
