### PR TITLE
Manually checkout the right tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          fetch-tags: true
+      - run: git fetch --tags --force origin ${{ github.ref }}
+      - run: git checkout ${{ github.ref }}
+      - run: git describe --always HEAD
       - uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
@@ -37,7 +39,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          fetch-tags: true
+      - run: git fetch --tags --force origin ${{ github.ref }}
+      - run: git checkout ${{ github.ref }}
+      - run: git describe --always HEAD
       - uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
@@ -58,7 +62,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          fetch-tags: true
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Fixes some GH checkout action weirdness that confuses git about the current tag at HEAD.

It probably relates to this? https://github.com/actions/checkout/issues/1467

I tried all kinds of other combinations:
- remove `fetch-tags`
- remove `fetch-depth`
- downgrade to `checkout@v3`

None of them solve it.

Manual solution seems to work: https://github.com/yfyf/driver/actions/runs/16260914298/job/45905767224#step:5:5