### PR TITLE
Avoid doing git operations after checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ github.ref }}
           fetch-depth: 0
           persist-credentials: false
-      - run: git fetch --tags --force origin ${GITHUB_REF}
-      - run: git checkout ${GITHUB_REF}
       - run: git describe --always HEAD
       - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31
         with:
@@ -37,10 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ github.ref }}
           fetch-depth: 0
           persist-credentials: false
-      - run: git fetch --tags --force origin ${GITHUB_REF}
-      - run: git checkout ${GITHUB_REF}
       - run: git describe --always HEAD
       - uses: cachix/install-nix-action@616559265b40713947b9c190a8ff4b507b5df49b # v31
         with:
@@ -62,6 +60,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ github.ref }}
           fetch-depth: 0
           persist-credentials: false
 


### PR DESCRIPTION
Noticed that this breaks builds in private repos, since without credentials it is not possible to fetch the tags.

This is future-proofing the usage of `persist-credentials: false`. For a public repo, this changes nothing. But if `driver` were to become a private repo or something in Github's logic were to change to block public reads, this would start failing.
